### PR TITLE
fix(cdk): use default VPC

### DIFF
--- a/cdk/helpers/env.ts
+++ b/cdk/helpers/env.ts
@@ -1,0 +1,16 @@
+import { GetCallerIdentityCommand, STSClient } from '@aws-sdk/client-sts'
+import type { Environment } from 'aws-cdk-lib'
+
+export const env = async ({
+	sts,
+}: {
+	sts: STSClient
+}): Promise<Required<Environment>> => {
+	const { Account } = await sts.send(new GetCallerIdentityCommand({}))
+	if (Account === undefined) throw new Error(`Failed to get caller identity!`)
+	return {
+		account: Account,
+		region:
+			process.env.AWS_REGION ?? process.env.AWS_DEFAULT_REGION ?? 'eu-west-1',
+	}
+}

--- a/cdk/helpers/lambdas/packLambdaFromPath.ts
+++ b/cdk/helpers/lambdas/packLambdaFromPath.ts
@@ -19,7 +19,6 @@ export const packLambdaFromPath = async (
 	const { handler } = await packLambda({
 		sourceFile: path.join(baseDir, sourceFile),
 		zipFile,
-		progress: console.debug,
 	})
 	return {
 		zipFile,

--- a/cdk/helpers/lambdas/packLambdaFromPath.ts
+++ b/cdk/helpers/lambdas/packLambdaFromPath.ts
@@ -19,6 +19,7 @@ export const packLambdaFromPath = async (
 	const { handler } = await packLambda({
 		sourceFile: path.join(baseDir, sourceFile),
 		zipFile,
+		progress: console.debug,
 	})
 	return {
 		zipFile,

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -5,7 +5,6 @@ import {
 	aws_iot as IoT,
 	Stack,
 } from 'aws-cdk-lib'
-import type { IVpc } from 'aws-cdk-lib/aws-ec2'
 import type { IRepository } from 'aws-cdk-lib/aws-ecr'
 import { LogDriver, type ICluster } from 'aws-cdk-lib/aws-ecs'
 import { RetentionDays } from 'aws-cdk-lib/aws-logs'
@@ -132,12 +131,10 @@ export class Integration extends Construct {
 			principal: this.bridgeCertificate.attrArn,
 		})
 
-		const vpc = new EC2.Vpc(this, `vpc`, {
-			maxAzs: 1,
-		})
+		const vpc = EC2.Vpc.fromLookup(this, 'DefaultVPC', { isDefault: true })
 
 		const cluster = new ECS.Cluster(this, `cluster`, {
-			vpc: vpc as IVpc,
+			vpc,
 		})
 
 		const mqttBridgeTask = new ECS.FargateTaskDefinition(this, 'mqttBridge')

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -267,7 +267,7 @@ export class Integration extends Construct {
 				cluster: cluster as ICluster,
 				taskDefinition: mqttBridgeTask,
 				desiredCount: 1,
-				assignPublicIp: this.node.tryGetContext('isTest') ?? false,
+				assignPublicIp: true,
 			},
 		)
 		// Add inbound port to security group

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -267,6 +267,7 @@ export class Integration extends Construct {
 				cluster: cluster as ICluster,
 				taskDefinition: mqttBridgeTask,
 				desiredCount: 1,
+				// Required for shared VPC and access to SSM Parameters
 				assignPublicIp: true,
 			},
 		)
@@ -275,28 +276,6 @@ export class Integration extends Construct {
 			EC2.Peer.anyIpv4(),
 			EC2.Port.tcp(1883),
 			'inbound-mqtt',
-		)
-		// Allow all outgoing traffic
-		mqttBridgeService.connections.allowTo(
-			EC2.Peer.anyIpv6(),
-			EC2.Port.allTcp(),
-			'outbound-ipv6-tcp',
-		)
-		mqttBridgeService.connections.allowTo(
-			EC2.Peer.anyIpv4(),
-			EC2.Port.allTcp(),
-			'outbound-ipv4-tcp',
-		)
-		// Allow all TLS traffic
-		mqttBridgeService.connections.allowFrom(
-			EC2.Peer.anyIpv6(),
-			EC2.Port.tcp(443),
-			'inbound-ipv6-tcp-tls',
-		)
-		mqttBridgeService.connections.allowFrom(
-			EC2.Peer.anyIpv4(),
-			EC2.Port.tcp(443),
-			'inbound-ipv4-tcp-tls',
 		)
 	}
 }

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -287,5 +287,16 @@ export class Integration extends Construct {
 			EC2.Port.allTcp(),
 			'outbound-ipv4-tcp',
 		)
+		// Allow all TLS traffic
+		mqttBridgeService.connections.allowFrom(
+			EC2.Peer.anyIpv6(),
+			EC2.Port.tcp(443),
+			'inbound-ipv6-tcp-tls',
+		)
+		mqttBridgeService.connections.allowFrom(
+			EC2.Peer.anyIpv4(),
+			EC2.Port.tcp(443),
+			'inbound-ipv4-tcp-tls',
+		)
 	}
 }

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -276,5 +276,16 @@ export class Integration extends Construct {
 			EC2.Port.tcp(1883),
 			'inbound-mqtt',
 		)
+		// Allow all outgoing traffic
+		mqttBridgeService.connections.allowTo(
+			EC2.Peer.anyIpv6(),
+			EC2.Port.allTcp(),
+			'outbound-ipv6-tcp',
+		)
+		mqttBridgeService.connections.allowTo(
+			EC2.Peer.anyIpv4(),
+			EC2.Port.allTcp(),
+			'outbound-ipv4-tcp',
+		)
 	}
 }

--- a/cdk/stacks/BackendStack.ts
+++ b/cdk/stacks/BackendStack.ts
@@ -1,4 +1,10 @@
-import { App, CfnOutput, aws_lambda as Lambda, Stack } from 'aws-cdk-lib'
+import {
+	App,
+	CfnOutput,
+	aws_lambda as Lambda,
+	Stack,
+	type Environment,
+} from 'aws-cdk-lib'
 import { type CAFiles } from '../../bridge/caLocation.js'
 import type { CertificateFiles } from '../../bridge/mqttBridgeCertificateLocation.js'
 import type { BackendLambdas } from '../BackendLambdas.js'
@@ -26,9 +32,9 @@ export class BackendStack extends Stack {
 			mqttBridgeCertificate,
 			caCertificate,
 			bridgeImageSettings,
-			region,
 			repository,
 			gitHubOICDProviderArn,
+			env,
 		}: {
 			lambdaSources: BackendLambdas
 			layer: PackedLayer
@@ -36,18 +42,16 @@ export class BackendStack extends Stack {
 			mqttBridgeCertificate: CertificateFiles
 			caCertificate: CAFiles
 			bridgeImageSettings: BridgeImageSettings
-			region: string
 			gitHubOICDProviderArn: string
 			repository: {
 				owner: string
 				repo: string
 			}
+			env: Required<Environment>
 		},
 	) {
 		super(parent, STACK_NAME, {
-			env: {
-				region,
-			},
+			env,
 		})
 
 		const baseLayer = new Lambda.LayerVersion(this, 'baseLayer', {

--- a/cdk/test-resources.ts
+++ b/cdk/test-resources.ts
@@ -1,6 +1,10 @@
+import { STSClient } from '@aws-sdk/client-sts'
+import { env } from './helpers/env.js'
 import { packLambdaFromPath } from './helpers/lambdas/packLambdaFromPath.js'
 import { packLayer } from './helpers/lambdas/packLayer.js'
 import { TestResources } from './test-resources/TestResourcesApp.js'
+
+const awsEnv = await env({ sts: new STSClient({}) })
 
 new TestResources({
 	lambdaSources: {
@@ -13,4 +17,5 @@ new TestResources({
 		id: 'testResources',
 		dependencies: ['@aws-sdk/client-dynamodb', '@nordicsemiconductor/from-env'],
 	}),
+	env: awsEnv,
 })

--- a/cdk/test-resources/TestResourcesApp.ts
+++ b/cdk/test-resources/TestResourcesApp.ts
@@ -1,4 +1,4 @@
-import { App } from 'aws-cdk-lib'
+import { App, type Environment } from 'aws-cdk-lib'
 import type { PackedLambda } from '../helpers/lambdas/packLambda'
 import type { PackedLayer } from '../helpers/lambdas/packLayer'
 import { TestResourcesStack } from './TestResourcesStack.js'
@@ -8,14 +8,16 @@ export class TestResources extends App {
 		lambdaSources,
 		context,
 		layer,
+		env,
 	}: {
 		lambdaSources: {
 			httpApiMock: PackedLambda
 		}
 		layer: PackedLayer
 		context?: Record<string, any>
+		env: Required<Environment>
 	}) {
 		super({ context })
-		new TestResourcesStack(this, { lambdaSources, layer })
+		new TestResourcesStack(this, { lambdaSources, layer, env })
 	}
 }

--- a/cdk/test-resources/TestResourcesStack.ts
+++ b/cdk/test-resources/TestResourcesStack.ts
@@ -1,4 +1,10 @@
-import { App, CfnOutput, aws_lambda as Lambda, Stack } from 'aws-cdk-lib'
+import {
+	App,
+	CfnOutput,
+	aws_lambda as Lambda,
+	Stack,
+	type Environment,
+} from 'aws-cdk-lib'
 import type { PackedLambda } from '../helpers/lambdas/packLambda.js'
 import type { PackedLayer } from '../helpers/lambdas/packLayer.js'
 import { TEST_RESOURCES_STACK_NAME } from '../stacks/stackConfig.js'
@@ -13,14 +19,16 @@ export class TestResourcesStack extends Stack {
 		{
 			lambdaSources,
 			layer,
+			env,
 		}: {
 			lambdaSources: {
 				httpApiMock: PackedLambda
 			}
 			layer: PackedLayer
+			env: Required<Environment>
 		},
 	) {
-		super(parent, TEST_RESOURCES_STACK_NAME)
+		super(parent, TEST_RESOURCES_STACK_NAME, { env })
 
 		const baseLayer = new Lambda.LayerVersion(this, 'baseLayer', {
 			code: Lambda.Code.fromAsset(layer.layerZipFile),


### PR DESCRIPTION
Because we do not need a custom VPC, the default can be used.

Fixes #17
