### PR TITLE
fix: handle non-200 http status code

### DIFF
--- a/lambda/util/getSSMParameter.ts
+++ b/lambda/util/getSSMParameter.ts
@@ -35,6 +35,8 @@ export const getSSMParameter = async (
 					},
 				}),
 			)
+			if (res.ok !== true) throw new Error(`HTTP status: ${res.status}`)
+
 			return res.json()
 		})
 		.then(async (payload) => {


### PR DESCRIPTION
Check `res.ok` before calling `res.json()`. 

Found this error

```
[AWS Parameters and Secrets Lambda Extension] 2023/06/19 22:28:15 INFO ready to serve traffic
[AWS Parameters and Secrets Lambda Extension] 2023/06/19 22:28:15 ERROR GetParameter request encountered an error: operation error SSM: GetParameter, https response error StatusCode: 400, RequestID: 6fa998e8-0d6f-4650-8bcd-2364928299d6, ParameterNotFound: 
2023-06-19T22:28:15.755Z	24f1eec7-128b-4b8f-9994-610b2cb6885b	INFO	{"res":{"status":200}}
2023-06-19T22:28:15.772Z	24f1eec7-128b-4b8f-9994-610b2cb6885b	INFO	{"payload":{"Parameter":{"ARN":"arn:aws:ssm:eu-west-1:812555912232:parameter/muninn/thirdParty/nrfcloud/apiKey","DataType":"text","LastModifiedDate":"2023-06-14T15:52:18.635Z","Name":"/muninn/thirdParty/nrfcloud/apiKey","Selector":null,"SourceResult":null,"Type":"String","Value":"824ae663419469ce05cd7b5634cd4a4cbf2a85a1","Version":2},"ResultMetadata":{}}}
2023-06-19T22:28:15.775Z	24f1eec7-128b-4b8f-9994-610b2cb6885b	INFO	{"res":{"status":400}}
2023-06-19T22:28:15.778Z	24f1eec7-128b-4b8f-9994-610b2cb6885b	ERROR	SyntaxError: Unexpected token a in JSON at position 0
    at JSON.parse (<anonymous>)
    at parseJSONFromBytes (node:internal/deps/undici/undici:6571:19)
    at successSteps (node:internal/deps/undici/undici:6545:27)
    at node:internal/deps/undici/undici:1211:60
    at node:internal/process/task_queues:140:7
    at AsyncResource.runInAsyncScope (node:async_hooks:203:9)
    at AsyncResource.runMicrotask (node:internal/process/task_queues:137:8)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```