### PR TITLE
refactor(ondevicemessage): do not cache if device model is not defined

### DIFF
--- a/devices/getModelForDevice.ts
+++ b/devices/getModelForDevice.ts
@@ -1,40 +1,38 @@
 import { DynamoDBClient, QueryCommand } from '@aws-sdk/client-dynamodb'
 import { unmarshall } from '@aws-sdk/util-dynamodb'
 
-export const getModelForDevice = ({
-	db,
-	DevicesTableName,
-}: {
-	db: DynamoDBClient
-	DevicesTableName: string
-}): ((deviceId: string) => Promise<{ model: string }>) => {
-	const deviceModelPromises: Record<string, Promise<{ model: string }>> = {}
-	return async (deviceId: string): Promise<{ model: string }> => {
-		let p = deviceModelPromises[deviceId]
-		if (p === undefined) {
-			p = db
-				.send(
-					new QueryCommand({
-						TableName: DevicesTableName,
-						KeyConditionExpression: '#deviceId = :deviceId',
-						ExpressionAttributeNames: {
-							'#deviceId': 'deviceId',
-						},
-						ExpressionAttributeValues: {
-							':deviceId': {
-								S: deviceId,
-							},
-						},
-					}),
-				)
-				.then((res) => ({
-					model:
-						res.Items?.[0] !== undefined
-							? (unmarshall(res.Items[0]).model as string)
-							: 'default',
-				}))
-			deviceModelPromises[deviceId] = p
-		}
-		return p
+export const getModelForDevice =
+	({
+		db,
+		DevicesTableName,
+	}: {
+		db: DynamoDBClient
+		DevicesTableName: string
+	}) =>
+	async (deviceId: string): Promise<{ model: string } | { error: Error }> => {
+		const { Items } = await db.send(
+			new QueryCommand({
+				TableName: DevicesTableName,
+				KeyConditionExpression: '#deviceId = :deviceId',
+				ExpressionAttributeNames: {
+					'#deviceId': 'deviceId',
+					'#model': 'model',
+				},
+				ExpressionAttributeValues: {
+					':deviceId': {
+						S: deviceId,
+					},
+				},
+				ProjectionExpression: '#model',
+			}),
+		)
+
+		const model = Items?.[0] !== undefined && unmarshall(Items[0]).model
+
+		if (model === undefined)
+			return {
+				error: new Error(`Not model defined for device ${deviceId}!`),
+			}
+
+		return { model }
 	}
-}


### PR DESCRIPTION
The device table is eventual consitent and in tests
the first time the device model is looked up the entry
might not exist. However previously the fallback value
"default" was cached and used in all subsequent retries.

This changes the caching strategy to only cache "good"
values and removes the "default" model which is not supported
anyway.

Fixes #31
