### PR TITLE
feat:  health-check script to check bridge connection

### DIFF
--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -1,4 +1,5 @@
 import {
+	Duration,
 	aws_ec2 as EC2,
 	aws_ecr as ECR,
 	aws_ecs as ECS,
@@ -193,7 +194,7 @@ export class Integration extends Construct {
 			MOSQUITTO__BRIDGE01__BRIDGE_KEYFILE: `/mosquitto/security/nrfcloud_client.key`,
 			MOSQUITTO__BRIDGE01__BRIDGE_INSECURE: `false`,
 			MOSQUITTO__BRIDGE01__START_TYPE: `automatic`,
-			MOSQUITTO__BRIDGE01__KEEPALIVE_INTERVAL: `10`,
+			MOSQUITTO__BRIDGE01__KEEPALIVE_INTERVAL: `30`,
 			MOSQUITTO__BRIDGE01__NOTIFICATIONS: `true`,
 			MOSQUITTO__BRIDGE01__NOTIFICATIONS_LOCAL_ONLY: `true`,
 			MOSQUITTO__BRIDGE01__CLEANSESSION: `true`,
@@ -211,9 +212,10 @@ export class Integration extends Construct {
 			MOSQUITTO__BRIDGE02__BRIDGE_CERTFILE: `/mosquitto/security/iot.crt`,
 			MOSQUITTO__BRIDGE02__BRIDGE_KEYFILE: `/mosquitto/security/iot.key`,
 			MOSQUITTO__BRIDGE02__BRIDGE_INSECURE: `false`,
+			MOSQUITTO__BRIDGE02__BRIDGE_TRY_PRIVATE: `true`,
 			MOSQUITTO__BRIDGE02__LOCAL_CLIENTID: `iot-bridge-local`,
 			MOSQUITTO__BRIDGE02__START_TYPE: `automatic`,
-			MOSQUITTO__BRIDGE02__KEEPALIVE_INTERVAL: `10`,
+			MOSQUITTO__BRIDGE02__KEEPALIVE_INTERVAL: `30`,
 			MOSQUITTO__BRIDGE02__NOTIFICATIONS: `true`,
 			MOSQUITTO__BRIDGE02__NOTIFICATIONS_LOCAL_ONLY: `true`,
 			MOSQUITTO__BRIDGE02__CLEANSESSION: `true`,
@@ -257,10 +259,11 @@ export class Integration extends Construct {
 			},
 			environment,
 			healthCheck: {
-				command: [
-					'CMD-SHELL',
-					'mosquitto_sub -p 1883 -t topic -C 1 -E -i probe -W 3',
-				],
+				command: ['CMD-SHELL', '/health.sh'],
+				interval: Duration.minutes(1),
+				retries: 3,
+				startPeriod: Duration.minutes(3),
+				timeout: Duration.seconds(5),
 			},
 		})
 

--- a/cdk/resources/containers/bridge/health.sh
+++ b/cdk/resources/containers/bridge/health.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+results=$(mosquitto_sub -p 1883 -t "\$SYS/broker/connection/#" -i health-check -C 2 -W 3 2>/dev/null)
+expected_results="1"$'\n'"1"
+
+if [[ "$results" == "$expected_results" ]]; then
+  echo "Both commands were successful."
+else
+  echo "One or both commands failed."
+  exit 1
+fi


### PR DESCRIPTION
- Change keepalive to 30s as per minimum value from AWS IoT, https://eu-north-1.console.aws.amazon.com/servicequotas/home/services/iotcore/quotas/L-E77027EF
- Enable `try_private` flag in mosquitto to increase performance, https://mosquitto.org/man/mosquitto-conf-5.html
- Change health check script to detect bridge connections. Once it is failed, then report as `unhealthy` to Fargate to reschedule a new task