### PR TITLE
feat: using docker buildx

### DIFF
--- a/aws/getOrBuildDockerImage.ts
+++ b/aws/getOrBuildDockerImage.ts
@@ -104,6 +104,7 @@ export const getOrBuildDockerImage =
 			await run({
 				command: 'docker',
 				args: [
+					'buildx',
 					'build',
 					'--platform',
 					'linux/amd64',


### PR DESCRIPTION
I am using Ubuntu 22.04 and docker version 24.0.2, build cb74dfc. Unfortunately, I couldn't reproduce the same error. So, to make sure we are using `buildx` command, we will explicitly call `buildx` when build the docker image.

@coderbyheart Would you please try again and let me know whether the warning message is gone.
