### PR TITLE
feat: add new scope for mqtt bridge

### DIFF
--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -106,7 +106,7 @@ export class Integration extends Construct {
 				simpleName: false,
 				parameterName: settingsPath({
 					stackName: Stack.of(this).stackName,
-					scope: Scope.STACK_CONFIG,
+					scope: Scope.STACK_MQTT_BRIDGE,
 					property: 'bridgeCertificatePEM',
 				}),
 			},
@@ -119,7 +119,7 @@ export class Integration extends Construct {
 				simpleName: false,
 				parameterName: settingsPath({
 					stackName: Stack.of(this).stackName,
-					scope: Scope.STACK_CONFIG,
+					scope: Scope.STACK_MQTT_BRIDGE,
 					property: 'bridgePrivateKey',
 				}),
 			},

--- a/util/settings.ts
+++ b/util/settings.ts
@@ -9,6 +9,7 @@ import { paginate } from './paginate.js'
 
 export enum Scope {
 	STACK_CONFIG = 'stack/context',
+	STACK_MQTT_BRIDGE = 'stack/mqttBridge',
 	NRFCLOUD_CONFIG = 'thirdParty/nrfcloud',
 	NRFCLOUD_BRIDGE_CERTIFICATE_MQTT = 'nRFCloudBridgeCertificate/MQTT',
 	NRFCLOUD_BRIDGE_CERTIFICATE_CA = 'nRFCloudBridgeCertificate/CA',


### PR DESCRIPTION
Separate SSM scope for its own because currently it shares SSM path with fetcher configuration and might cause the error in the future. 

**Note** This PR will NOT pass the test due to the permission error. There is the separated PR for that, https://github.com/hello-nrfcloud/backend/pull/117.