### PR TITLE
feat(cli): align configure command

### DIFF
--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -73,10 +73,10 @@ jobs:
         run: |
           npx cdk --app "npx tsx --no-warnings cdk/test-resources.ts" deploy --require-approval never
           MOCK_HTTP_API_ENDPOINT=`aws cloudformation describe-stacks --stack-name ${{ env.STACK_NAME }}-test | jq -r '.Stacks[0].Outputs[] | select(.OutputKey == "apiURL") | .OutputValue' | sed -E 's/\/$//g'`
-          ./cli.sh configure thirdParty/acme/apiEndpoint ${MOCK_HTTP_API_ENDPOINT}
-          ./cli.sh configure thirdParty/acme/apiKey apiKey_Acme
-          ./cli.sh configure thirdParty/elite/apiEndpoint ${MOCK_HTTP_API_ENDPOINT}
-          ./cli.sh configure thirdParty/elite/apiKey apiKey_Elite
+          ./cli.sh configure-nrfcloud-account acme apiEndpoint ${MOCK_HTTP_API_ENDPOINT}
+          ./cli.sh configure-nrfcloud-account acme apiKey apiKey_Acme
+          ./cli.sh configure-nrfcloud-account elite apiEndpoint ${MOCK_HTTP_API_ENDPOINT}
+          ./cli.sh configure-nrfcloud-account elite apiKey apiKey_Elite
 
       - name: Deploy solution stack
         env:
@@ -119,11 +119,11 @@ jobs:
           npx cdk destroy -f
           npx cdk --app 'npx tsx --no-warnings cdk/test-resources.ts' destroy -f
           ./cli.sh fake-nrfcloud-account-device acme --remove
-          ./cli.sh configure thirdParty/acme/apiEndpoint -X
-          ./cli.sh configure thirdParty/acme/apiKey -X
+          ./cli.sh configure-nrfcloud-account acme apiEndpoint -X
+          ./cli.sh configure-nrfcloud-account acme apiKey -X
           ./cli.sh fake-nrfcloud-account-device elite --remove
-          ./cli.sh configure thirdParty/elite/apiEndpoint -X
-          ./cli.sh configure thirdParty/elite/apiKey -X
+          ./cli.sh configure-nrfcloud-account elite apiEndpoint -X
+          ./cli.sh configure-nrfcloud-account elite apiKey -X
           ./cli.sh clean-backup-certificates
 
   release:

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ certificate used by MQTT broker to connect nRF Cloud under your account. So, you
 need to prepare nRF Cloud API key.
 
 ```bash
-./cli.sh configure thirdParty/<account>/apiKey <API key>
+./cli.sh configure-nrfcloud-account <account> apiKey <API key>
 ./cli.sh initialize-nrfcloud-account <account>
 ./cli.sh create-health-check-device <account>
 ```

--- a/cdk/resources/ConfigureDevice.ts
+++ b/cdk/resources/ConfigureDevice.ts
@@ -12,6 +12,7 @@ import type { PackedLambda } from '../helpers/lambdas/packLambda.js'
 import { LambdaSource } from './LambdaSource.js'
 import type { WebsocketAPI } from './WebsocketAPI.js'
 import { Context } from '@hello.nrfcloud.com/proto/hello'
+import { Scope } from '../../util/settings.js'
 
 /**
  * Handles device configuration requests
@@ -56,10 +57,14 @@ export class ConfigureDevice extends Construct {
 					resources: [
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty/*`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}/*`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
 						}:parameter/${Stack.of(this).stackName}/nRFCloud/accounts`,

--- a/cdk/resources/DeviceShadow.ts
+++ b/cdk/resources/DeviceShadow.ts
@@ -15,6 +15,7 @@ import { Construct } from 'constructs'
 import type { PackedLambda } from '../helpers/lambdas/packLambda'
 import { LambdaSource } from './LambdaSource.js'
 import type { WebsocketAPI } from './WebsocketAPI.js'
+import { Scope } from '../../util/settings.js'
 
 export class DeviceShadow extends Construct {
 	public constructor(
@@ -120,10 +121,14 @@ export class DeviceShadow extends Construct {
 					resources: [
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty/*`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}/*`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
 						}:parameter/${Stack.of(this).stackName}/nRFCloud/accounts`,

--- a/cdk/resources/HealthCheckMqttBridge.ts
+++ b/cdk/resources/HealthCheckMqttBridge.ts
@@ -13,6 +13,7 @@ import type { PackedLambda } from '../helpers/lambdas/packLambda.js'
 import type { DeviceStorage } from './DeviceStorage.js'
 import type { WebsocketAPI } from './WebsocketAPI.js'
 import { LambdaSource } from './LambdaSource.js'
+import { Scope } from '../../util/settings.js'
 
 export type BridgeImageSettings = BridgeSettings
 
@@ -64,10 +65,14 @@ export class HealthCheckMqttBridge extends Construct {
 					resources: [
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty/*`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}/*`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
 						}:parameter/${Stack.of(this).stackName}/nRFCloud/accounts`,

--- a/cdk/resources/Integration.ts
+++ b/cdk/resources/Integration.ts
@@ -221,7 +221,7 @@ export class Integration extends Construct {
 		const { environment, secrets } = Object.entries(nRFCloudAccounts).reduce(
 			(result, [account], index) => {
 				const bridgeNo = String(index + 2).padStart(2, '0')
-				const scope = `thirdParty/${account}`
+				const scope = `${Scope.NRFCLOUD_ACCOUNT_PREFIX}/${account}`
 				const bridgePrefix = `MOSQUITTO__BRIDGE${bridgeNo}`
 
 				result.environment[

--- a/cdk/resources/SingleCellGeoLocation.ts
+++ b/cdk/resources/SingleCellGeoLocation.ts
@@ -12,6 +12,7 @@ import { LambdaSource } from './LambdaSource.js'
 import type { WebsocketAPI } from './WebsocketAPI.js'
 import { IoTActionRole } from './IoTActionRole.js'
 import type { DeviceStorage } from './DeviceStorage.js'
+import { Scope } from '../../util/settings.js'
 
 /**
  * Resolve device geo location based on network information
@@ -61,10 +62,14 @@ export class SingleCellGeoLocation extends Construct {
 					resources: [
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
-						}:parameter/${Stack.of(this).stackName}/thirdParty/*`,
+						}:parameter/${Stack.of(this).stackName}/${
+							Scope.NRFCLOUD_ACCOUNT_PREFIX
+						}/*`,
 						`arn:aws:ssm:${Stack.of(this).region}:${
 							Stack.of(this).account
 						}:parameter/${Stack.of(this).stackName}/nRFCloud/accounts`,

--- a/cli/cli.ts
+++ b/cli/cli.ts
@@ -13,7 +13,6 @@ import { STACK_NAME } from '../cdk/stacks/stackConfig.js'
 import psjon from '../package.json'
 import type { CommandDefinition } from './commands/CommandDefinition'
 import { configureDeviceCommand } from './commands/configure-device.js'
-import { configureCommand } from './commands/configure.js'
 import { createFakeNrfCloudAccountDeviceCredentials } from './commands/create-fake-nrfcloud-account-device-credentials.js'
 import { createFakeNrfCloudHealthCheckDevice } from './commands/create-fake-nrfcloud-health-check-device.js'
 import { createHealthCheckDevice } from './commands/create-health-check-device.js'
@@ -30,6 +29,7 @@ import { showNRFCloudAccount } from './commands/show-nrfcloud-account.js'
 import { simulateDeviceCommand } from './commands/simulate-device.js'
 import { cleanBackupCertificates } from './commands/clean-backup-certificates.js'
 import { listnRFCloudAccountsCommand } from './commands/list-nrfcloud-accounts.js'
+import { configureRFCloudAccountCommand } from './commands/configure-nrfcloud-account.js'
 
 const ssm = new SSMClient({})
 const iot = new IoTClient({})
@@ -60,7 +60,7 @@ const CLI = async ({ isCI }: { isCI: boolean }) => {
 	program.version(psjon.version)
 
 	const commands: CommandDefinition[] = [
-		configureCommand({ ssm }),
+		configureRFCloudAccountCommand({ ssm }),
 		setShadowFetcherCommand({ ssm }),
 		logsCommand({ stackName: STACK_NAME, cf, logs }),
 		cleanBackupCertificates({ ssm }),

--- a/lambda/ws/AuthorizedEvent.ts
+++ b/lambda/ws/AuthorizedEvent.ts
@@ -7,7 +7,7 @@ export type AuthorizedEvent = APIGatewayProxyWebsocketEventV2 & {
 			model: string //e.g. "PCA20035+solar",
 			integrationLatency: 1043
 			deviceId: string // e.g. 'oob-352656108602296'
-			account: string // e.g. 'exeger'
+			account: string // e.g. 'elite'
 		}
 	}
 }

--- a/nrfcloud/allAccounts.ts
+++ b/nrfcloud/allAccounts.ts
@@ -19,14 +19,17 @@ export const getAllnRFCloudAccounts = async ({
 }: {
 	ssm: SSMClient
 	stackName: string
-}): Promise<string[]> =>
-	Object.keys(
-		await getSettings({
-			ssm,
-			stackName,
-			scope: Scope.NRFCLOUD_ACCOUNT,
-		})(),
-	)
+}): Promise<string[]> => [
+	...new Set(
+		Object.keys(
+			await getSettings({
+				ssm,
+				stackName,
+				scope: Scope.NRFCLOUD_ACCOUNT_PREFIX,
+			})(),
+		).map((key) => key.split('/')[0] as string),
+	),
+]
 
 export const getAllAccountsSettings =
 	({ ssm, stackName }: { ssm: SSMClient; stackName: string }) =>

--- a/nrfcloud/healthCheckSettings.ts
+++ b/nrfcloud/healthCheckSettings.ts
@@ -1,5 +1,9 @@
 import type { SSMClient } from '@aws-sdk/client-ssm'
-import { getSettings as getSSMSettings, putSettings } from '../util/settings.js'
+import {
+	Scope,
+	getSettings as getSSMSettings,
+	putSettings,
+} from '../util/settings.js'
 
 export type Settings = {
 	healthCheckClientCert: string
@@ -21,7 +25,7 @@ export const updateSettings = ({
 	const settingsWriter = putSettings({
 		ssm,
 		stackName,
-		scope: `thirdParty/${account}`,
+		scope: `${Scope.NRFCLOUD_ACCOUNT_PREFIX}/${account}`,
 	})
 	return async (settings): Promise<void> => {
 		await Promise.all(
@@ -44,7 +48,7 @@ export const getSettings = ({
 	stackName: string
 	account: string
 }): (() => Promise<Settings>) => {
-	const scope = `thirdParty/${account}`
+	const scope = `${Scope.NRFCLOUD_ACCOUNT_PREFIX}/${account}`
 	const settingsReader = getSSMSettings({
 		ssm,
 		stackName,

--- a/nrfcloud/initializeAccount.ts
+++ b/nrfcloud/initializeAccount.ts
@@ -3,14 +3,14 @@ import { SSMClient } from '@aws-sdk/client-ssm'
 import chalk from 'chalk'
 import { getIoTEndpoint } from '../aws/getIoTEndpoint.js'
 import { STACK_NAME } from '../cdk/stacks/stackConfig.js'
-import { Scope, getSettings, putSettings } from '../util/settings.js'
+import { Scope, getSettings } from '../util/settings.js'
 import { createAccountDevice } from './createAccountDevice.js'
 import { deleteAccountDevice } from './deleteNrfcloudCredentials.js'
 import { getAccountInfo } from './getAccountInfo.js'
 import {
 	defaultApiEndpoint,
 	getSettings as getNRFCloudSettings,
-	updateSettings,
+	putSettings as putNRFCloudSettings,
 	type Settings,
 } from './settings.js'
 
@@ -30,7 +30,7 @@ export const initializeAccount =
 		account: string
 	}) =>
 	async (reset = false): Promise<void> => {
-		const scope = `thirdParty/${account}`
+		const scope = `${Scope.NRFCLOUD_ACCOUNT_PREFIX}/${account}`
 		const settingsReader = getSettings({
 			ssm,
 			stackName,
@@ -98,13 +98,7 @@ export const initializeAccount =
 			}
 			console.log(chalk.green(`Account device created.`))
 
-			await putSettings({
-				ssm,
-				stackName: STACK_NAME,
-				scope: Scope.NRFCLOUD_ACCOUNT,
-			})({ property: account, value: account })
-
-			await updateSettings({ ssm, stackName: STACK_NAME, scope })({
+			await putNRFCloudSettings({ ssm, stackName: STACK_NAME, account })({
 				accountDeviceClientCert: clientCert,
 				accountDevicePrivateKey: privateKey,
 				accountDeviceClientId: `account-${accountInfo.tenantId}`,

--- a/util/settings.spec.ts
+++ b/util/settings.spec.ts
@@ -37,11 +37,11 @@ describe('settingsPath()', () => {
 	it('should produce a fully qualified parameter name for valid string scope', () =>
 		expect(
 			settingsPath({
-				scope: 'thirdParty/exeger',
+				scope: 'thirdParty/elite',
 				stackName: 'hello-nrfcloud',
 				property: 'someProperty',
 			}),
-		).toEqual('/hello-nrfcloud/thirdParty/exeger/someProperty'))
+		).toEqual('/hello-nrfcloud/thirdParty/elite/someProperty'))
 
 	it('should error for invalid string scope', () => {
 		expect(() =>

--- a/util/settings.ts
+++ b/util/settings.ts
@@ -12,13 +12,13 @@ export enum Scope {
 	STACK_MQTT_BRIDGE = 'stack/mqttBridge',
 	NRFCLOUD_BRIDGE_CERTIFICATE_MQTT = 'nRFCloudBridgeCertificate/MQTT',
 	NRFCLOUD_BRIDGE_CERTIFICATE_CA = 'nRFCloudBridgeCertificate/CA',
-	NRFCLOUD_ACCOUNT = 'nRFCloud/accounts',
+	NRFCLOUD_ACCOUNT_PREFIX = 'thirdParty',
 }
 
 const validScope = (scope: string): boolean => {
 	return (
 		Object.values(Scope).map(String).includes(scope) ||
-		/^thirdParty\/[a-zA-Z0-9_.-]+$/.test(scope)
+		new RegExp(`^${Scope.NRFCLOUD_ACCOUNT_PREFIX}/[a-zA-Z0-9_.-]+$`).test(scope)
 	)
 }
 


### PR DESCRIPTION
This changes the configure command to follow the other acount
related commands and now accepts an account name instead of
a scope.

In addition, the nRFCloud/accounts/<account> with value <account>
SSMParameter has been removed because the list of active accounts
can be determined by looking at which accounts have been configured.
