### PR TITLE
fix: lambda invoked by API GW needed to return result

### DIFF
--- a/lambda/onMessage.ts
+++ b/lambda/onMessage.ts
@@ -187,4 +187,11 @@ const h = async (event: AuthorizedEvent): Promise<void> => {
 	await onSuccess(maybeValidRequest.request)
 }
 
-export const handler = middy(h).use(logMetrics(metrics))
+export const handler = middy(h)
+	.use(logMetrics(metrics))
+	.use({
+		after: async (request) => {
+			const { response } = request
+			if (response === undefined) request.response = { statusCode: 200 }
+		},
+	})


### PR DESCRIPTION
When web socket client sends request, there is response similar to this, even there is no error.

```
{"message":"Internal Server Error", "connectionId": "...", "requestId": "..." }
```

This is because lambda does not return any response to API gateway.