### PR TITLE
Add locked metric and missing connection id

### DIFF
--- a/cdk/resources/DeviceShadow.ts
+++ b/cdk/resources/DeviceShadow.ts
@@ -174,7 +174,7 @@ export class DeviceShadow extends Construct {
 		fetchDeviceShadow.addEventSource(
 			new EventSources.SqsEventSource(shadowQueue, {
 				batchSize: 10,
-				maxConcurrency: 2,
+				maxConcurrency: 15,
 			}),
 		)
 		this.deviceShadowTable.grantWriteData(fetchDeviceShadow)

--- a/lambda/fetchDeviceShadow.ts
+++ b/lambda/fetchDeviceShadow.ts
@@ -81,6 +81,7 @@ const h = async (): Promise<void> => {
 	try {
 		const lockAcquired = await lock.acquiredLock(lockName, lockTTLSeconds)
 		if (lockAcquired === false) {
+			track('locked', MetricUnits.Count, 1)
 			log.info(`Other process is still running, then ignore`)
 			return
 		}
@@ -160,7 +161,9 @@ const h = async (): Promise<void> => {
 							).map(async (devices) =>
 								limit(async () => {
 									const start = Date.now()
-									log.debug(`Prepare fetching shadow under ${account} account`)
+									log.debug(
+										`Prepare fetching shadow under ${account} account: ${devices.length} devices`,
+									)
 									const res = await deviceShadow(
 										devices.map((device) => device.deviceId),
 									)

--- a/websocket/connectionsRepository.ts
+++ b/websocket/connectionsRepository.ts
@@ -132,6 +132,7 @@ export const connectionsRepository: (
 						'#version': 'version',
 						'#updatedAt': 'updatedAt',
 						'#count': 'count',
+						'#connectionId': 'connectionId',
 					},
 					ExpressionAttributeValues: {
 						':version': { N: version.toString() },
@@ -139,7 +140,7 @@ export const connectionsRepository: (
 						':increase': { N: '1' },
 					},
 					ConditionExpression:
-						'attribute_not_exists(#version) OR #version <= :version',
+						'attribute_exists(#connectionId) AND (attribute_not_exists(#version) OR #version <= :version)',
 					ReturnValues: 'ALL_OLD',
 				}),
 			)


### PR DESCRIPTION
During our load test with the default configuration (where shadow fetching occurs every 5 seconds), we observed a significant number of missing shadow messages compared to our initial expectations. To investigate this issue, we implemented addition metrics to gain better insights into the problem:

### FetchDeviceShadow Function

1.  `locked`: This metric counts instances when the function is still processing a previous request when it is invoked again.

### OnMessage Function

During the load test, we encountered errors in the `onMessage` function, preventing it from updating the database as expected when certain conditions were not met. To address this issue, we took the following actions:

1.  **Error Handling**: We introduced error handling mechanisms to properly manage errors encountered in the `onMessage` function.
    
2.  `connectionIdMissing`: This metric was added to count the number of times the `onMessage` function failed to update the data due to condition mismatches.

### FetchDeviceShadow invocation rate

During our load test, we expected the `fetchDeviceShadow` function to be invoked 12 times per minute, as it is triggered by SQS every 5 seconds. However, we observed that the average invocation rate was only 6 times per minute. After a thorough investigation, we determined that this discrepancy was due to a concurrency limit of 2 on the function. To align with our desired invocation rate, we made the necessary adjustment by increasing the `maxConcurrency` to 15.

<img width="1317" alt="MicrosoftTeams-imagea9e62581afd4e14826cb00a487492cc5140946d32fabde4e2c44d75bd88198d4" src="https://github.com/hello-nrfcloud/backend/assets/2525169/7420ff6c-ed78-4f9f-90b2-0c66055deb56">

