### PR TITLE
fix: add retry logic to websocket connection

### DIFF
--- a/feature-runner/lib/websocket.ts
+++ b/feature-runner/lib/websocket.ts
@@ -31,7 +31,7 @@ export const createWebsocketClient = ({
 							resolve()
 						})
 						.on('error', (error) => {
-							debug?.(`!! Connection error: ${error.message}`)
+							debug?.(`Connection error: ${error.message}`)
 							reject(new Error(`Connection to ${url} failed.`))
 						})
 						.on('message', async (msg) => {

--- a/feature-runner/lib/websocket.ts
+++ b/feature-runner/lib/websocket.ts
@@ -30,7 +30,8 @@ export const createWebsocketClient = ({
 						.on('open', () => {
 							resolve()
 						})
-						.on('error', () => {
+						.on('error', (error) => {
+							debug?.(`!! Connection error: ${error.message}`)
 							reject(new Error(`Connection to ${url} failed.`))
 						})
 						.on('message', async (msg) => {

--- a/feature-runner/steps/websocket.ts
+++ b/feature-runner/steps/websocket.ts
@@ -48,7 +48,17 @@ const wsConnect = ({ websocketUri }: { websocketUri: string }) =>
 					url: wsURL,
 					debug: (...args) => progress('[ws]', ...args),
 				})
-				await wsClients[wsURL]?.connect()
+				await pRetry(
+					async (attempt: number) => {
+						progress(`(Attempt: ${attempt}) Connecting websocket`)
+						await wsClients[wsURL]?.connect()
+					},
+					{
+						retries: 5,
+						minTimeout: 500,
+						maxTimeout: 1000,
+					},
+				)
 			}
 
 			context.wsClient = wsClients[wsURL] as WebSocketClient


### PR DESCRIPTION
There is an issue that test is failed due to websocket connection, https://github.com/hello-nrfcloud/backend/actions/runs/6183891652/job/16786519316?pr=259.

There is no log what cause the connection is failed. So, this PR will introduce logging error when the connection is failed and also retry logic to websocket connection.