### PR TITLE
Fix: update AccountInfo schema

### DIFF
--- a/nrfcloud/apiClient.spec.ts
+++ b/nrfcloud/apiClient.spec.ts
@@ -2,7 +2,7 @@ import { validateWithTypeBox } from '@hello.nrfcloud.com/proto'
 import { AccountInfo } from './apiClient.js'
 
 describe('apiClient()', () => {
-	it('should validate enterprice plan API Client response', () => {
+	it('should validate enterprise plan API Client response', () => {
 		const APIresponse = {
 			mqttEndpoint: 'mqtt.nrfcloud.com',
 			mqttTopicPrefix: 'prod/b8b26bc5-2814-4063-b4fa-83ecddb2fec7/',

--- a/nrfcloud/apiClient.spec.ts
+++ b/nrfcloud/apiClient.spec.ts
@@ -1,0 +1,74 @@
+import { validateWithTypeBox } from '@hello.nrfcloud.com/proto'
+import { AccountInfo } from './apiClient.js'
+
+describe('apiClient()', () => {
+	it('should validate enterprice plan API Client response', () => {
+		const APIresponse = {
+			mqttEndpoint: 'mqtt.nrfcloud.com',
+			mqttTopicPrefix: 'prod/b8b26bc5-2814-4063-b4fa-83ecddb2fec7/',
+			team: {
+				tenantId: 'b8b26bc5-2814-4063-b4fa-83ecddb2fec7',
+				name: 'XXX',
+			},
+			role: 'owner',
+			tags: [],
+			plan: {
+				name: 'ENTERPRISE',
+				proxyUsageDeclarations: {
+					AGPS: 0,
+					PGPS: 0,
+					GROUND_FIX: 0,
+				},
+				serviceKeys: [
+					{
+						service: 'ALL',
+						enabled: true,
+						createdAt: '2023-09-14T10:24:31.663Z',
+					},
+				],
+				currentMonthCosts: [
+					{
+						serviceId: 'Devices',
+						serviceDescription: 'Devices in your account',
+						quantity: 53,
+						price: 0.1,
+						total: 5.3,
+					},
+					{
+						serviceId: 'Messages',
+						serviceDescription: 'Device messages stored',
+						quantity: 70281,
+						price: 0.0001,
+						total: 7.03,
+					},
+					{
+						serviceId: 'AGPS',
+						serviceDescription: 'Assisted GPS Service: total requests',
+						quantity: 8,
+						price: 0.001,
+						total: 0.01,
+					},
+					{
+						serviceId: 'SCELL',
+						serviceDescription: 'Single-Cell Location Service: total requests',
+						quantity: 2684,
+						price: 0.001,
+						total: 2.68,
+					},
+					{
+						serviceId: 'MCELL',
+						serviceDescription: 'Multi-Cell Location Service: total requests',
+						quantity: 4505,
+						price: 0.002,
+						total: 9.01,
+					},
+				],
+				currentMonthTotalCost: 24.03,
+			},
+		}
+
+		const maybeData = validateWithTypeBox(AccountInfo)(APIresponse)
+
+		expect('errors' in maybeData).toBe(false)
+	})
+})

--- a/nrfcloud/apiClient.ts
+++ b/nrfcloud/apiClient.ts
@@ -96,7 +96,7 @@ const Page = <T extends TSchema>(Item: T) =>
 	})
 const Devices = Page(Device)
 
-const AccountInfo = Type.Object({
+export const AccountInfo = Type.Object({
 	mqttEndpoint: Type.String(), // e.g. 'mqtt.nrfcloud.com'
 	mqttTopicPrefix: Type.String(), // e.g. 'prod/a0673464-e4e1-4b87-bffd-6941a012067b/',
 	team: Type.Object({
@@ -114,17 +114,29 @@ const AccountInfo = Type.Object({
 					Type.Literal('Messages'),
 					Type.Literal('SCELL'),
 					Type.Literal('MCELL'),
+					Type.Literal('AGPS'),
 				]),
 				total: Type.Number(), // e.g. 0.9
 			}),
 		),
 		currentMonthTotalCost: Type.Number(), // e.g. 2.73
-		name: Type.Union([Type.Literal('PRO'), Type.Literal('DEVELOPER')]),
+		name: Type.Union([
+			Type.Literal('PRO'),
+			Type.Literal('DEVELOPER'),
+			Type.Literal('ENTERPRISE'),
+		]),
 		proxyUsageDeclarations: Type.Object({
 			AGPS: Type.Number(), // e.g. 0
 			GROUND_FIX: Type.Number(), // e.g. 200
 			PGPS: Type.Number(), // e.g. 0
 		}),
+		serviceKeys: Type.Array(
+			Type.Object({
+				createdAt: Type.String(),
+				enabled: Type.Boolean(),
+				service: Type.String(),
+			}),
+		),
 	}),
 	role: Type.Union([
 		Type.Literal('owner'),

--- a/nrfcloud/apiClient.ts
+++ b/nrfcloud/apiClient.ts
@@ -104,39 +104,12 @@ export const AccountInfo = Type.Object({
 		name: Type.String(), // e.g. 'hello.nrfcloud.com'
 	}),
 	plan: Type.Object({
-		currentMonthCosts: Type.Array(
-			Type.Object({
-				price: Type.Number(), // e.g. 0.1
-				quantity: Type.Number(), // e.g. 9
-				serviceDescription: Type.String(), // e.g. 'Devices in your account'
-				serviceId: Type.Union([
-					Type.Literal('Devices'),
-					Type.Literal('Messages'),
-					Type.Literal('SCELL'),
-					Type.Literal('MCELL'),
-					Type.Literal('AGPS'),
-				]),
-				total: Type.Number(), // e.g. 0.9
-			}),
-		),
 		currentMonthTotalCost: Type.Number(), // e.g. 2.73
-		name: Type.Union([
-			Type.Literal('PRO'),
-			Type.Literal('DEVELOPER'),
-			Type.Literal('ENTERPRISE'),
-		]),
 		proxyUsageDeclarations: Type.Object({
 			AGPS: Type.Number(), // e.g. 0
 			GROUND_FIX: Type.Number(), // e.g. 200
 			PGPS: Type.Number(), // e.g. 0
 		}),
-		serviceKeys: Type.Array(
-			Type.Object({
-				createdAt: Type.String(),
-				enabled: Type.Boolean(),
-				service: Type.String(),
-			}),
-		),
 	}),
 	role: Type.Union([
 		Type.Literal('owner'),


### PR DESCRIPTION
Closes #278 

The API response were not considered valid since the possible names in 'plan' did not include the name 'ENTERPRISE' in the validation. In addition the 'serviceID' in 'currentMonthCosts' did not include 'AGPS' in the validation. 

'currentMonthCosts' and 'name' is not used in the code, and is removed from the validation. 