### PR TITLE
feat: validate nRF Cloud API response

### DIFF
--- a/lambda/fetchDeviceShadow.ts
+++ b/lambda/fetchDeviceShadow.ts
@@ -215,9 +215,7 @@ const h = async (): Promise<void> => {
 					'shadowAge',
 					MetricUnits.Seconds,
 					Math.round(Date.now() / 1000) -
-						getShadowUpdateTime(
-							deviceShadow.state.metadata as Record<string, any>,
-						),
+						getShadowUpdateTime(deviceShadow.state.metadata),
 				)
 
 				log.info(

--- a/lambda/fetchDeviceShadow.ts
+++ b/lambda/fetchDeviceShadow.ts
@@ -215,7 +215,9 @@ const h = async (): Promise<void> => {
 					'shadowAge',
 					MetricUnits.Seconds,
 					Math.round(Date.now() / 1000) -
-						getShadowUpdateTime(deviceShadow.state.metadata),
+						getShadowUpdateTime(
+							deviceShadow.state.metadata as Record<string, any>,
+						),
 				)
 
 				log.info(

--- a/lambda/loggingFetch.ts
+++ b/lambda/loggingFetch.ts
@@ -1,6 +1,32 @@
 import { MetricUnits } from '@aws-lambda-powertools/metrics'
 import type { AddMetricsFn } from './metrics/metrics'
 import type { Logger } from '@aws-lambda-powertools/logger'
+import type { ErrorObject } from 'ajv'
+import type { Static, TObject } from '@sinclair/typebox'
+import { validateWithTypeBox } from '@hello.nrfcloud.com/proto'
+
+export class ValidationError extends Error {
+	public errors: ErrorObject[]
+	public readonly isValidationError = true
+	constructor(errors: ErrorObject[]) {
+		super(`Validation errors`)
+		this.name = 'ValidationError'
+		this.errors = errors
+	}
+}
+
+const validate = <T extends TObject>(
+	SchemaObject: T,
+	data: unknown,
+): Static<T> => {
+	const maybeData = validateWithTypeBox(SchemaObject)(data)
+
+	if ('errors' in maybeData) {
+		throw new ValidationError(maybeData.errors)
+	}
+
+	return maybeData.value
+}
 
 export const loggingFetch =
 	({ track, log }: { track: AddMetricsFn; log: Logger }) =>
@@ -21,3 +47,30 @@ export const loggingFetch =
 
 		return res
 	}
+
+export const validatedLoggingFetch = (
+	...args: Parameters<typeof loggingFetch>
+): (<Schema extends TObject>(
+	url: URL,
+	init: RequestInit,
+	schema: Schema,
+) => Promise<
+	{ error: Error | ValidationError } | { result: Static<Schema> }
+>) => {
+	const lf = loggingFetch(...args)
+	return async (url, init = {}, schema) => {
+		try {
+			const response = await lf(url, init)
+			if (!response.ok)
+				throw new Error(`Error fetching status: ${response.status}`)
+
+			return { result: validate(schema, await response.json()) }
+		} catch (error: unknown) {
+			if (error instanceof ValidationError) {
+				return { error }
+			} else {
+				return { error: error as Error }
+			}
+		}
+	}
+}

--- a/lambda/loggingFetch.ts
+++ b/lambda/loggingFetch.ts
@@ -1,36 +1,13 @@
 import { MetricUnits } from '@aws-lambda-powertools/metrics'
 import type { AddMetricsFn } from './metrics/metrics'
 import type { Logger } from '@aws-lambda-powertools/logger'
-import type { ErrorObject } from 'ajv'
-import type { Static, TObject } from '@sinclair/typebox'
-import { validateWithTypeBox } from '@hello.nrfcloud.com/proto'
-
-export class ValidationError extends Error {
-	public errors: ErrorObject[]
-	public readonly isValidationError = true
-	constructor(errors: ErrorObject[]) {
-		super(`Validation errors`)
-		this.name = 'ValidationError'
-		this.errors = errors
-	}
-}
-
-const validate = <T extends TObject>(
-	SchemaObject: T,
-	data: unknown,
-): Static<T> => {
-	const maybeData = validateWithTypeBox(SchemaObject)(data)
-
-	if ('errors' in maybeData) {
-		throw new ValidationError(maybeData.errors)
-	}
-
-	return maybeData.value
-}
 
 export const loggingFetch =
 	({ track, log }: { track: AddMetricsFn; log: Logger }) =>
-	async (url: URL, init?: RequestInit): ReturnType<typeof fetch> => {
+	async (
+		url: URL | RequestInfo,
+		init?: RequestInit,
+	): ReturnType<typeof fetch> => {
 		log.debug(`fetch:url`, url.toString())
 		if (init?.body !== null && init?.body !== undefined)
 			log.debug(`fetch:body`, init.body.toString())
@@ -47,30 +24,3 @@ export const loggingFetch =
 
 		return res
 	}
-
-export const validatedLoggingFetch = (
-	...args: Parameters<typeof loggingFetch>
-): (<Schema extends TObject>(
-	url: URL,
-	init: RequestInit,
-	schema: Schema,
-) => Promise<
-	{ error: Error | ValidationError } | { result: Static<Schema> }
->) => {
-	const lf = loggingFetch(...args)
-	return async (url, init = {}, schema) => {
-		try {
-			const response = await lf(url, init)
-			if (!response.ok)
-				throw new Error(`Error fetching status: ${response.status}`)
-
-			return { result: validate(schema, await response.json()) }
-		} catch (error: unknown) {
-			if (error instanceof ValidationError) {
-				return { error }
-			} else {
-				return { error: error as Error }
-			}
-		}
-	}
-}

--- a/lambda/resolveSingleCellGeoLocation.ts
+++ b/lambda/resolveSingleCellGeoLocation.ts
@@ -21,7 +21,7 @@ import { getDeviceAttributesById } from './getDeviceAttributes.js'
 import { metricsForComponent } from './metrics/metrics.js'
 import type { WebsocketPayload } from './publishToWebsocketClients.js'
 import { logger } from './util/logger.js'
-import { validatedFetch } from '../nrfcloud/validatedFetch.js'
+import { JSONPayload, validatedFetch } from '../nrfcloud/validatedFetch.js'
 import { loggingFetch } from './loggingFetch.js'
 
 const { EventBusName, stackName, DevicesTableName, cacheTableName } = fromEnv({
@@ -158,18 +158,13 @@ const h = async (event: {
 			],
 		}
 
-		const vf = validatedFetch({ endpoint: apiEndpoint, apiKey }, trackFetch)
+		const vf = validatedFetch(
+			{ endpoint: apiEndpoint, apiKey: locationServiceToken },
+			trackFetch,
+		)
 		const maybeResult = await vf(
-			{ resource: 'location/ground-fix' },
+			{ resource: 'location/ground-fix', payload: JSONPayload(body) },
 			GroundFix,
-			{
-				method: 'POST',
-				headers: {
-					'Content-Type': 'application/json',
-					Authorization: `Bearer ${locationServiceToken}`,
-				},
-				body: JSON.stringify(body),
-			},
 		)
 
 		if ('error' in maybeResult) {

--- a/lambda/ws/sendShadowToConnection.ts
+++ b/lambda/ws/sendShadowToConnection.ts
@@ -5,7 +5,7 @@ import {
 	PutEventsCommand,
 } from '@aws-sdk/client-eventbridge'
 import { proto } from '@hello.nrfcloud.com/proto/hello/model/PCA20035+solar'
-import { type DeviceShadow } from '../../nrfcloud/DeviceShadow.js'
+import { type DeviceShadowType } from '../../nrfcloud/DeviceShadow.js'
 import type { AddMetricsFn } from '../metrics/metrics.js'
 import type { WebsocketPayload } from '../publishToWebsocketClients.js'
 
@@ -26,7 +26,7 @@ export const sendShadowToConnection =
 		connectionId,
 		shadow,
 	}: {
-		shadow: DeviceShadow
+		shadow: DeviceShadowType
 		model: string
 		connectionId: string
 	}): Promise<void> => {

--- a/nrfcloud/DeviceShadow.spec.ts
+++ b/nrfcloud/DeviceShadow.spec.ts
@@ -1,0 +1,52 @@
+import { validateWithTypeBox } from '@hello.nrfcloud.com/proto'
+import { DeviceShadow } from './DeviceShadow.js'
+
+describe('DeviceShadow type', () => {
+	it('should document the device shadow object', () => {
+		const res = validateWithTypeBox(DeviceShadow)({
+			id: 'some-device',
+			state: {
+				version: 42,
+				reported: {
+					dev: {
+						v: {
+							imei: '358299840016535',
+							iccid: '89450421180216254864',
+							modV: 'mfw_nrf91x1_2.0.0-77.beta',
+							brdV: 'thingy91x_nrf9161',
+							appV: '0.0.0-development',
+						},
+						ts: 1697102116821,
+					},
+				},
+				metadata: {
+					reported: {
+						dev: {
+							v: {
+								imei: {
+									timestamp: 1697102122,
+								},
+								iccid: {
+									timestamp: 1697102122,
+								},
+								modV: {
+									timestamp: 1697102122,
+								},
+								brdV: {
+									timestamp: 1697102122,
+								},
+								appV: {
+									timestamp: 1697102122,
+								},
+							},
+							ts: {
+								timestamp: 1697102122,
+							},
+						},
+					},
+				},
+			},
+		})
+		expect(res).not.toHaveProperty('errors')
+	})
+})

--- a/nrfcloud/DeviceShadow.ts
+++ b/nrfcloud/DeviceShadow.ts
@@ -1,8 +1,22 @@
-export type DeviceShadow = {
-	id: string
-	state: {
-		reported: Record<string, any>
-		version: number
-		metadata: Record<string, any>
-	}
-}
+import { Type, type Static } from '@sinclair/typebox'
+
+const PropertyMetadata = Type.Union([
+	Type.Object({ timestamp: Type.Integer({ minimum: 1, maximum: 9999999999 }) }),
+	Type.Record(Type.String({ minLength: 1 }), Type.Unknown()),
+])
+
+/**
+ * @link https://api.nrfcloud.com/v1/#tag/All-Devices/operation/ListDevices
+ */
+export const DeviceShadow = Type.Object({
+	id: Type.String(),
+	state: Type.Object({
+		reported: Type.Object({}),
+		version: Type.Number(),
+		metadata: Type.Object({
+			reported: Type.Record(Type.String({ minLength: 1 }), PropertyMetadata),
+		}),
+	}),
+})
+
+export type DeviceShadowType = Static<typeof DeviceShadow>

--- a/nrfcloud/createAccountDevice.ts
+++ b/nrfcloud/createAccountDevice.ts
@@ -1,10 +1,13 @@
-import { Type } from '@sinclair/typebox'
+import { Type, type Static } from '@sinclair/typebox'
 import { validatedFetch } from './validatedFetch.js'
 
-export type CertificateCredentials = {
-	clientCert: string
-	privateKey: string
-}
+/**
+ * @link https://api.nrfcloud.com/v1/#tag/Account-Devices/operation/CreateAccountDevice
+ */
+const CertificateCredentials = Type.Object({
+	clientCert: Type.String(),
+	privateKey: Type.String(),
+})
 
 export const createAccountDevice = async ({
 	apiKey,
@@ -12,22 +15,18 @@ export const createAccountDevice = async ({
 }: {
 	apiKey: string
 	endpoint: URL
-}): Promise<CertificateCredentials> => {
+}): Promise<Static<typeof CertificateCredentials>> => {
 	const vf = validatedFetch({ endpoint, apiKey })
 	const maybeResult = await vf(
 		{ resource: 'devices/account' },
-		Type.Object({
-			clientCert: Type.String(),
-			privateKey: Type.String(),
-		}),
+		CertificateCredentials,
 		{
 			method: 'POST',
 		},
 	)
 
 	if ('error' in maybeResult) {
-		console.error(`Failed to create account device:`, maybeResult.error)
-		throw new Error(`Failed to create account device`)
+		throw maybeResult.error
 	}
 
 	return {

--- a/nrfcloud/createAccountDevice.ts
+++ b/nrfcloud/createAccountDevice.ts
@@ -18,11 +18,8 @@ export const createAccountDevice = async ({
 }): Promise<Static<typeof CertificateCredentials>> => {
 	const vf = validatedFetch({ endpoint, apiKey })
 	const maybeResult = await vf(
-		{ resource: 'devices/account' },
+		{ resource: 'devices/account', method: 'POST' },
 		CertificateCredentials,
-		{
-			method: 'POST',
-		},
 	)
 
 	if ('error' in maybeResult) {

--- a/nrfcloud/deviceShadowRepo.spec.ts
+++ b/nrfcloud/deviceShadowRepo.spec.ts
@@ -1,11 +1,11 @@
 import type { DynamoDBClient } from '@aws-sdk/client-dynamodb'
 import { store, get } from './deviceShadowRepo.js'
-import type { DeviceShadow } from './DeviceShadow'
+import type { DeviceShadowType } from './DeviceShadow'
 import { check, objectMatching } from 'tsmatchers'
 import { marshall } from '@aws-sdk/util-dynamodb'
 import { ResourceNotFoundException } from '@aws-sdk/client-iot'
 
-const shadow: DeviceShadow = {
+const shadow: DeviceShadowType = {
 	id: 'someId',
 	tags: ['configuration:solar-shield', 'model:PCA20035'],
 	tenantId: 'a0673464-e4e1-4b87-bffd-6941a012067b',

--- a/nrfcloud/deviceShadowRepo.ts
+++ b/nrfcloud/deviceShadowRepo.ts
@@ -4,7 +4,7 @@ import {
 	type DynamoDBClient,
 } from '@aws-sdk/client-dynamodb'
 import { marshall, unmarshall } from '@aws-sdk/util-dynamodb'
-import type { DeviceShadow } from './DeviceShadow'
+import type { DeviceShadowType } from './DeviceShadow'
 
 /**
  * Store the updated shadow in DynamoDB for sending it right after a client connects
@@ -16,7 +16,7 @@ export const store =
 	}: {
 		db: DynamoDBClient
 		TableName: string
-	}): ((shadow: DeviceShadow) => Promise<void>) =>
+	}): ((shadow: DeviceShadowType) => Promise<void>) =>
 	async (shadow) => {
 		await db.send(
 			new PutItemCommand({
@@ -38,7 +38,7 @@ export const get =
 	}: {
 		db: DynamoDBClient
 		TableName: string
-	}): ((deviceId: string) => Promise<{ shadow: DeviceShadow | null }>) =>
+	}): ((deviceId: string) => Promise<{ shadow: DeviceShadowType | null }>) =>
 	async (deviceId) => {
 		try {
 			const { Item } = await db.send(
@@ -52,7 +52,7 @@ export const get =
 				}),
 			)
 			const { shadow } = unmarshall(Item as Record<string, never>) as {
-				shadow: DeviceShadow
+				shadow: DeviceShadowType
 			}
 			return { shadow }
 		} catch {

--- a/nrfcloud/devices.ts
+++ b/nrfcloud/devices.ts
@@ -189,14 +189,16 @@ export const devices = (
 				.map((cols) => cols.join(','))
 				.join('\n')
 
-			const maybeResult = await vf({ resource: 'devices' }, ProvisionDevice, {
-				method: 'POST',
-				headers: {
-					Authorization: `Bearer ${apiKey}`,
-					'Content-Type': 'application/octet-stream',
+			const maybeResult = await vf(
+				{
+					resource: 'devices',
+					payload: {
+						body: bulkRegistrationPayload,
+						type: 'application/octet-stream',
+					},
 				},
-				body: bulkRegistrationPayload,
-			})
+				ProvisionDevice,
+			)
 
 			if ('error' in maybeResult) {
 				return {

--- a/nrfcloud/devices.ts
+++ b/nrfcloud/devices.ts
@@ -84,6 +84,9 @@ const Page = <T extends TSchema>(Item: T) =>
 	})
 const Devices = Page(Device)
 
+/**
+ * @link https://api.nrfcloud.com/v1/#tag/IP-Devices/operation/ProvisionDevices
+ */
 const ProvisionDevice = Type.Object({
 	bulkOpsRequestId: Type.String(),
 })

--- a/nrfcloud/getDeviceShadowFromnRFCloud.ts
+++ b/nrfcloud/getDeviceShadowFromnRFCloud.ts
@@ -2,12 +2,15 @@ import { Type, type Static } from '@sinclair/typebox'
 import { logger } from '../lambda/util/logger.js'
 import { validatedFetch } from './validatedFetch.js'
 
+/**
+ * @link https://api.nrfcloud.com/v1/#tag/All-Devices/operation/ListDevices
+ */
 const DeviceShadow = Type.Object({
 	id: Type.String(),
 	state: Type.Object({
-		reported: Type.Record(Type.String(), Type.Any()),
+		reported: Type.Record(Type.String(), Type.Unknown()),
 		version: Type.Number(),
-		metadata: Type.Record(Type.String(), Type.Any()),
+		metadata: Type.Record(Type.String(), Type.Unknown()),
 	}),
 })
 

--- a/nrfcloud/getDeviceShadowFromnRFCloud.ts
+++ b/nrfcloud/getDeviceShadowFromnRFCloud.ts
@@ -1,20 +1,38 @@
+import { Type, type Static } from '@sinclair/typebox'
 import { logger } from '../lambda/util/logger.js'
-import { slashless } from '../util/slashless.js'
-import { type DeviceShadow } from './DeviceShadow.js'
+import { validatedFetch } from './validatedFetch.js'
+
+const DeviceShadow = Type.Object({
+	id: Type.String(),
+	state: Type.Object({
+		reported: Type.Record(Type.String(), Type.Any()),
+		version: Type.Number(),
+		metadata: Type.Record(Type.String(), Type.Any()),
+	}),
+})
+
+const DeviceShadows = Type.Array(DeviceShadow)
+
+const ListDevices = Type.Object({
+	items: DeviceShadows,
+	total: Type.Number(),
+	pageNextToken: Type.String(),
+})
 
 const log = logger('deviceShadowFetcher')
 
-export const deviceShadowFetcher =
-	({
-		endpoint,
-		apiKey,
-		onError,
-	}: {
-		endpoint: URL
-		apiKey: string
-		onError?: (res: Response) => void
-	}) =>
-	async (devices: string[]): Promise<DeviceShadow[]> => {
+export const deviceShadowFetcher = ({
+	endpoint,
+	apiKey,
+	onError,
+}: {
+	endpoint: URL
+	apiKey: string
+	onError?: (error: Error) => void
+}): ((devices: string[]) => Promise<Static<typeof DeviceShadows>>) => {
+	const vf = validatedFetch({ endpoint, apiKey })
+
+	return async (devices) => {
 		const params = {
 			includeState: true,
 			includeStateMeta: true,
@@ -25,27 +43,16 @@ export const deviceShadowFetcher =
 			.sort((a, b) => a[0].localeCompare(b[0]))
 			.map((kv) => kv.map(encodeURIComponent).join('='))
 			.join('&')
-		const url = `${slashless(endpoint)}/v1/devices?${queryString}`
+		const url = `devices?${queryString}`
 
 		log.info(`Fetching device shadow`, { url })
-		// Change to bulk fetching device shadow otherwise it might hit rate limit
-		// FIXME: validate response
-		const res = await fetch(url, {
-			method: 'get',
-			headers: {
-				Authorization: `Bearer ${apiKey}`,
-			},
-		})
-
-		if (res.ok) {
-			const data = await res.json()
-			return data.items as DeviceShadow[]
-		} else {
-			onError?.(res)
-			log.error(`Fetching shadow error`, {
-				status: res.status,
-				statusText: res.statusText,
-			})
+		const maybeResult = await vf({ resource: url }, ListDevices)
+		if ('error' in maybeResult) {
+			onError?.(maybeResult.error)
+			log.error(`Fetching shadow error`, { error: maybeResult.error })
 			return []
 		}
+
+		return maybeResult.result.items
 	}
+}

--- a/nrfcloud/getDeviceShadowFromnRFCloud.ts
+++ b/nrfcloud/getDeviceShadowFromnRFCloud.ts
@@ -1,18 +1,7 @@
 import { Type, type Static } from '@sinclair/typebox'
 import { logger } from '../lambda/util/logger.js'
 import { validatedFetch } from './validatedFetch.js'
-
-/**
- * @link https://api.nrfcloud.com/v1/#tag/All-Devices/operation/ListDevices
- */
-const DeviceShadow = Type.Object({
-	id: Type.String(),
-	state: Type.Object({
-		reported: Type.Record(Type.String(), Type.Unknown()),
-		version: Type.Number(),
-		metadata: Type.Record(Type.String(), Type.Unknown()),
-	}),
-})
+import { DeviceShadow } from './DeviceShadow.js'
 
 const DeviceShadows = Type.Array(DeviceShadow)
 

--- a/nrfcloud/validatedFetch.spec.ts
+++ b/nrfcloud/validatedFetch.spec.ts
@@ -50,4 +50,41 @@ describe('validatedFetch()', () => {
 			await vf({ resource: 'some-resource' }, mockFetch as any),
 		).toMatchObject({ error: err })
 	})
+
+	it('should override the defaults if init parameter is provided', async () => {
+		const mockFetch = jest.fn(() => ({
+			ok: true,
+			json: async () =>
+				Promise.resolve({
+					foo: 'bar',
+				}),
+		}))
+		const vf = validatedFetch(
+			{
+				endpoint: new URL('https://example.com/'),
+				apiKey: 'some-key',
+			},
+			mockFetch as any,
+		)
+		const schema = Type.Object({ foo: Type.Literal('bar') })
+
+		const res = await vf({ resource: 'foo' }, schema, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer another-key',
+				'Content-Type': 'application/octet-stream',
+			},
+		})
+
+		expect(res).not.toHaveProperty('error')
+		expect(res).toHaveProperty('result')
+		expect('result' in res && res.result).toMatchObject({ foo: 'bar' })
+		expect(mockFetch).toHaveBeenCalledWith(`https://example.com/v1/foo`, {
+			method: 'POST',
+			headers: {
+				Authorization: 'Bearer another-key',
+				'Content-Type': 'application/octet-stream',
+			},
+		})
+	})
 })

--- a/nrfcloud/validatedFetch.ts
+++ b/nrfcloud/validatedFetch.ts
@@ -43,23 +43,55 @@ export const validatedFetch =
 		fetchImplementation?: typeof fetch,
 	) =>
 	async <Schema extends TObject>(
-		{ resource }: { resource: string },
+		params:
+			| {
+					resource: string
+			  }
+			| {
+					resource: string
+					payload: Payload
+			  }
+			| {
+					resource: string
+					method: string
+			  },
 		schema: Schema,
-		init?: RequestInit,
-	): Promise<{ error: Error | ValidationError } | { result: Static<Schema> }> =>
-		fetchData(fetchImplementation)(`${slashless(endpoint)}/v1/${resource}`, {
-			headers: {
-				...headers(apiKey),
-				'Content-Type': 'application/json',
-			},
-			...(init ?? {}),
-		})
+	): Promise<
+		{ error: Error | ValidationError } | { result: Static<Schema> }
+	> => {
+		const { resource } = params
+		const args: Parameters<typeof fetch>[1] = {
+			headers: headers(apiKey),
+		}
+		if ('payload' in params) {
+			const payload = params.payload
+			args.method = 'POST'
+			args.body = payload.body
+			args.headers = { ...(args.headers ?? {}), ['Content-Type']: payload.type }
+		} else if ('method' in params) {
+			args.method = params.method
+		}
+		return fetchData(fetchImplementation)(
+			`${slashless(endpoint)}/v1/${resource}`,
+			args,
+		)
 			.then((res) => ({ result: validate(schema, res) }))
 			.catch((error: Error): { error: Error | ValidationError } => ({
 				error,
 			}))
+	}
 
 const headers = (apiKey: string) => ({
 	Authorization: `Bearer ${apiKey}`,
 	Accept: 'application/json; charset=utf-8',
+})
+
+type Payload = {
+	/** The content-type of body */
+	type: string
+	body: string
+}
+export const JSONPayload = (payload: Record<string, unknown>): Payload => ({
+	type: 'application/json',
+	body: JSON.stringify(payload),
 })

--- a/nrfcloud/validatedFetch.ts
+++ b/nrfcloud/validatedFetch.ts
@@ -20,6 +20,7 @@ const validate = <T extends TObject>(
 	const maybeData = validateWithTypeBox(SchemaObject)(data)
 
 	if ('errors' in maybeData) {
+		console.error('Validation failed', { error: maybeData.errors })
 		throw new ValidationError(maybeData.errors)
 	}
 
@@ -31,9 +32,7 @@ const fetchData =
 	async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
 		const response = await (fetchImplementation ?? fetch)(...args)
 		if (!response.ok)
-			throw new Error(
-				`Error fetching status: ${response.status} - ${response.statusText}`,
-			)
+			throw new Error(`Error fetching status: ${response.status}`)
 
 		return response.json()
 	}

--- a/nrfcloud/validatedFetch.ts
+++ b/nrfcloud/validatedFetch.ts
@@ -31,7 +31,9 @@ const fetchData =
 	async (...args: Parameters<typeof fetch>): ReturnType<typeof fetch> => {
 		const response = await (fetchImplementation ?? fetch)(...args)
 		if (!response.ok)
-			throw new Error(`Error fetching status: ${response.status}`)
+			throw new Error(
+				`Error fetching status: ${response.status} - ${response.statusText}`,
+			)
 
 		return response.json()
 	}
@@ -44,12 +46,14 @@ export const validatedFetch =
 	async <Schema extends TObject>(
 		{ resource }: { resource: string },
 		schema: Schema,
+		init?: RequestInit,
 	): Promise<{ error: Error | ValidationError } | { result: Static<Schema> }> =>
 		fetchData(fetchImplementation)(`${slashless(endpoint)}/v1/${resource}`, {
 			headers: {
 				...headers(apiKey),
 				'Content-Type': 'application/json',
 			},
+			...(init ?? {}),
 		})
 			.then((res) => ({ result: validate(schema, res) }))
 			.catch((error: Error): { error: Error | ValidationError } => ({


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces validation for the nRF Cloud API responses. It uses the AJV (Another JSON Schema Validator) library and the TypeBox library to define and validate the schema of the responses. In case of validation errors, a ValidationError is thrown. The PR affects multiple files, mainly focusing on implementing the validation in the fetch functions and updating the function calls accordingly.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

`lambda/loggingFetch.ts`: Added a ValidationError class and a validate function to validate the schema of the responses. Also, introduced a new function validatedLoggingFetch which validates the response before returning it.
`lambda/resolveSingleCellGeoLocation.ts`: Replaced loggingFetch with validatedLoggingFetch and updated the function calls to handle the validation errors.
`nrfcloud/createAccountDevice.ts`: Replaced the fetch call with a call to validatedFetch and handled the validation errors.
`nrfcloud/devices.ts`: Replaced the fetch call with a call to validatedFetch and handled the validation errors.
`nrfcloud/getDeviceShadowFromnRFCloud.ts`: Replaced the fetch call with a call to validatedFetch and handled the validation errors.
`nrfcloud/validatedFetch.ts`: Introduced a new function validatedFetch which validates the response before returning it.
</details>
