### PR TITLE
Fix dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@middy/core": "4.7.0",
         "@nordicsemiconductor/from-env": "2.0.0",
         "@nordicsemiconductor/timestream-helpers": "6.0.1",
-        "@sinclair/typebox": "0.31.22",
+        "@sinclair/typebox": "0.31.23",
         "ajv": "8.12.0",
         "lodash-es": "4.17.21",
         "p-limit": "5.0.0",
@@ -7085,6 +7085,12 @@
         "npm": ">=9.0.0"
       }
     },
+    "node_modules/@nordicsemiconductor/bdd-markdown/node_modules/@sinclair/typebox": {
+      "version": "0.31.22",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.22.tgz",
+      "integrity": "sha512-CKviMgpcXd8q8IsQQD8cCleswe4/EkQRcOqtVQcP1e+XUyszjJYjgL5Dtf3XunWZc2zEGmQPqJEsq08NiW9xfw==",
+      "dev": true
+    },
     "node_modules/@nordicsemiconductor/cloudformation-helpers": {
       "version": "9.0.2",
       "dev": true,
@@ -7341,9 +7347,9 @@
       }
     },
     "node_modules/@sinclair/typebox": {
-      "version": "0.31.22",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.22.tgz",
-      "integrity": "sha512-CKviMgpcXd8q8IsQQD8cCleswe4/EkQRcOqtVQcP1e+XUyszjJYjgL5Dtf3XunWZc2zEGmQPqJEsq08NiW9xfw=="
+      "version": "0.31.23",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.23.tgz",
+      "integrity": "sha512-ZzrzE8yCrWWU4mcBstBgdlBMjB8My3ESY9nZ/v996GptIJb4+MU1p7s1Qxrc2xvZeOiDDnAheLLmdHjPgZV79g=="
     },
     "node_modules/@sindresorhus/is": {
       "version": "4.6.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "@aws-lambda-powertools/metrics": "1.14.2",
-        "@hello.nrfcloud.com/proto": "5.5.18",
+        "@hello.nrfcloud.com/proto": "5.5.19",
         "@middy/core": "4.7.0",
         "@nordicsemiconductor/from-env": "2.0.0",
         "@nordicsemiconductor/timestream-helpers": "6.0.1",
@@ -6879,11 +6879,11 @@
       }
     },
     "node_modules/@hello.nrfcloud.com/proto": {
-      "version": "5.5.18",
-      "resolved": "https://registry.npmjs.org/@hello.nrfcloud.com/proto/-/proto-5.5.18.tgz",
-      "integrity": "sha512-VuyfRe07/WHeDNInyurCAWRWo8g3GURBgTt6i/W+JrbgGbhA9ThPyd6yGTIkNk7Hwfet8DmJGqDcIm+QsCRsYw==",
+      "version": "5.5.19",
+      "resolved": "https://registry.npmjs.org/@hello.nrfcloud.com/proto/-/proto-5.5.19.tgz",
+      "integrity": "sha512-QEsjeACJJJB4TbRPQueXdm4Hucub4uBxBzzeZrtf2pznMVLFtA1sIO0Q2KhqUtV8ayyq3+Nf26lN33w3fZXuGQ==",
       "dependencies": {
-        "@sinclair/typebox": "0.31.22",
+        "@sinclair/typebox": "0.31.23",
         "ajv": "8.12.0",
         "jsonata": "2.0.3"
       },
@@ -6891,6 +6891,11 @@
         "node": ">=20.0.0",
         "npm": ">=9.0.0"
       }
+    },
+    "node_modules/@hello.nrfcloud.com/proto/node_modules/@sinclair/typebox": {
+      "version": "0.31.23",
+      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.23.tgz",
+      "integrity": "sha512-ZzrzE8yCrWWU4mcBstBgdlBMjB8My3ESY9nZ/v996GptIJb4+MU1p7s1Qxrc2xvZeOiDDnAheLLmdHjPgZV79g=="
     },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,7 @@
         "@aws-sdk/util-dynamodb": "3.449.0",
         "@commitlint/config-conventional": "18.4.0",
         "@nordicsemiconductor/asset-tracker-cloud-code-style": "12.0.109",
-        "@nordicsemiconductor/bdd-markdown": "7.0.9",
+        "@nordicsemiconductor/bdd-markdown": "7.0.10",
         "@nordicsemiconductor/cloudformation-helpers": "9.0.2",
         "@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript": "16.0.23",
         "@nordicsemiconductor/firmware-ci-device-helpers": "14.0.201",
@@ -6892,11 +6892,6 @@
         "npm": ">=9.0.0"
       }
     },
-    "node_modules/@hello.nrfcloud.com/proto/node_modules/@sinclair/typebox": {
-      "version": "0.31.23",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.23.tgz",
-      "integrity": "sha512-ZzrzE8yCrWWU4mcBstBgdlBMjB8My3ESY9nZ/v996GptIJb4+MU1p7s1Qxrc2xvZeOiDDnAheLLmdHjPgZV79g=="
-    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.13",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
@@ -7068,12 +7063,12 @@
       }
     },
     "node_modules/@nordicsemiconductor/bdd-markdown": {
-      "version": "7.0.9",
-      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/bdd-markdown/-/bdd-markdown-7.0.9.tgz",
-      "integrity": "sha512-MMs5gdK7zk6dQgSjCfIOtq8vAOJ6lw2rSnJj127ZPqEW3sGdUSlE1IHcXg9h1q9SvUjPmuG91BQEPf0PiAXBXA==",
+      "version": "7.0.10",
+      "resolved": "https://registry.npmjs.org/@nordicsemiconductor/bdd-markdown/-/bdd-markdown-7.0.10.tgz",
+      "integrity": "sha512-0ZN86YqzomQvfNhQCpAZOe2sH1o5FFnLZLgHieCB3xPXc/7qIuvSh5ieyrcXspXdnHyzz5Wdo0QSEvv74Bmnhg==",
       "dev": true,
       "dependencies": {
-        "@sinclair/typebox": "0.31.22",
+        "@sinclair/typebox": "0.31.23",
         "ajv": "8.12.0",
         "chalk": "5.3.0",
         "jsonata": "2.0.3",
@@ -7084,12 +7079,6 @@
         "node": ">=20.0.0",
         "npm": ">=9.0.0"
       }
-    },
-    "node_modules/@nordicsemiconductor/bdd-markdown/node_modules/@sinclair/typebox": {
-      "version": "0.31.22",
-      "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.31.22.tgz",
-      "integrity": "sha512-CKviMgpcXd8q8IsQQD8cCleswe4/EkQRcOqtVQcP1e+XUyszjJYjgL5Dtf3XunWZc2zEGmQPqJEsq08NiW9xfw==",
-      "dev": true
     },
     "node_modules/@nordicsemiconductor/cloudformation-helpers": {
       "version": "9.0.2",

--- a/package.json
+++ b/package.json
@@ -121,7 +121,7 @@
   "prettier": "@nordicsemiconductor/asset-tracker-cloud-code-style/.prettierrc",
   "dependencies": {
     "@aws-lambda-powertools/metrics": "1.14.2",
-    "@hello.nrfcloud.com/proto": "5.5.18",
+    "@hello.nrfcloud.com/proto": "5.5.19",
     "@middy/core": "4.7.0",
     "@nordicsemiconductor/from-env": "2.0.0",
     "@nordicsemiconductor/timestream-helpers": "6.0.1",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "@middy/core": "4.7.0",
     "@nordicsemiconductor/from-env": "2.0.0",
     "@nordicsemiconductor/timestream-helpers": "6.0.1",
-    "@sinclair/typebox": "0.31.22",
+    "@sinclair/typebox": "0.31.23",
     "ajv": "8.12.0",
     "lodash-es": "4.17.21",
     "p-limit": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/util-dynamodb": "3.449.0",
     "@commitlint/config-conventional": "18.4.0",
     "@nordicsemiconductor/asset-tracker-cloud-code-style": "12.0.109",
-    "@nordicsemiconductor/bdd-markdown": "7.0.9",
+    "@nordicsemiconductor/bdd-markdown": "7.0.10",
     "@nordicsemiconductor/cloudformation-helpers": "9.0.2",
     "@nordicsemiconductor/eslint-config-asset-tracker-cloud-typescript": "16.0.23",
     "@nordicsemiconductor/firmware-ci-device-helpers": "14.0.201",


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR updates the versions of three dependencies:
- `@hello.nrfcloud.com/proto` is updated from version 5.5.18 to 5.5.19.
- `@sinclair/typebox` is updated from version 0.31.22 to 0.31.23.
- `@nordicsemiconductor/bdd-markdown` is updated from version 7.0.9 to 7.0.10.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `package-lock.json`: The versions of `@hello.nrfcloud.com/proto`, `@sinclair/typebox`, and `@nordicsemiconductor/bdd-markdown` are updated in the lock file. The integrity hashes and resolved URLs are also updated accordingly.
- `package.json`: The versions of `@hello.nrfcloud.com/proto`, `@sinclair/typebox`, and `@nordicsemiconductor/bdd-markdown` are updated in the package.json file.
</details>

___
## User Description:
We need to merge all packages with the same version of `typebox` all together to pass the test
