### PR TITLE
ci: run unit test on macos on push

### DIFF
--- a/.github/workflows/run-unit-test-on-macos.yaml
+++ b/.github/workflows/run-unit-test-on-macos.yaml
@@ -2,8 +2,7 @@ name: Run unit test on MacOS
 
 on:
   push:
-    branches:
-      - test-script
+  workflow_dispatch:
 
 permissions:
   id-token: write


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR updates the GitHub Actions workflow for running unit tests on MacOS. The main changes include:
- The workflow is now triggered on any push event, instead of only on pushes to the 'test-script' branch.
- The workflow can also be manually triggered via the 'workflow_dispatch' event.
- The permissions for the workflow have been set to 'write' for 'id-token', 'contents', 'issues', and 'actions'.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/run-unit-test-on-macos.yaml`: Updated the trigger events for the workflow and set the permissions to 'write' for various resources.
</details>
