### PR TITLE
Fix coap measurement

### DIFF
--- a/cdk/resources/containers/coap/src/handler.ts
+++ b/cdk/resources/containers/coap/src/handler.ts
@@ -41,8 +41,8 @@ const run = async ({
 					return reject(error)
 				}
 
-				const outputs = (stdout || stderr).replace(/^[\d\-:,\s]+|\s*$/gm, '')
-				return resolve(outputs.split(os.EOL))
+				const outputs = stdout || stderr
+				return resolve(outputs.split(os.EOL).filter(Boolean))
 			},
 		)
 	})
@@ -81,11 +81,20 @@ export const handler: Handler<Event, EventResponse> = async (event) => {
 			os.tmpdir(),
 			`${event.deviceProperties.deviceId}.properties`,
 		)
+		const deviceDtlsSession = path.join(
+			os.tmpdir(),
+			`${event.deviceProperties.deviceId}.properties.session`,
+		)
 		createDeviceProperties(devicePropertiesFile, event.deviceProperties)
 
 		const result = await run({
 			command: 'coap-simulator/bin/coap-simulator',
-			args: event.args.concat(['-c', devicePropertiesFile]),
+			args: event.args.concat([
+				'--config',
+				devicePropertiesFile,
+				'--dtls-session',
+				deviceDtlsSession,
+			]),
 		})
 
 		const response = {

--- a/lambda/healthCheckForCoAP.ts
+++ b/lambda/healthCheckForCoAP.ts
@@ -193,13 +193,15 @@ const h = async (): Promise<void> => {
 					validate: async (message) => {
 						try {
 							const data = store.get(account)
+							if (data === undefined) return ValidateResponse.skip
+
 							const messageObj = JSON.parse(message)
 							log.debug(`ws incoming message`, { messageObj })
 							const expectedMessage = {
 								'@context':
 									'https://github.com/hello-nrfcloud/proto/transformed/PCA20035%2Bsolar/airTemperature',
-								ts: data?.ts,
-								c: data?.temperature,
+								ts: data.ts,
+								c: data.temperature,
 							}
 
 							if (messageObj['@context'] !== expectedMessage['@context'])
@@ -208,7 +210,7 @@ const h = async (): Promise<void> => {
 							track(
 								`receivingMessageDuration`,
 								MetricUnits.Seconds,
-								(Date.now() - (data?.coapTs ?? data?.ts ?? 0)) / 1000,
+								(Date.now() - (data.coapTs ?? data.ts)) / 1000,
 							)
 							assert.deepEqual(messageObj, expectedMessage)
 							return ValidateResponse.valid

--- a/util/parseDateTimeFromLogToTimestamp.spec.ts
+++ b/util/parseDateTimeFromLogToTimestamp.spec.ts
@@ -1,0 +1,26 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+
+import { parseDateTimeFromLogToTimestamp } from './parseDateTimeFromLogToTimestamp.js'
+
+void describe('parseDateTimeFromLogToTimestamp', () => {
+	void it('should return a timestamp when a valid log string is provided', () => {
+		const dateUTCStr = `2023-11-15 01:53:06.148Z`
+		const expected =
+			Date.parse(dateUTCStr) + new Date().getTimezoneOffset() * 60 * 1000
+
+		const logString =
+			'2023-11-15 01:53:06,148 INFO [coap.nrfcloud.com/3.84.64.178:5684] Reconnected [CID:, peerCID:cdf04e555d32fa5cbb5d, peer-cert:CN=coap.nrfcloud.com, cipher-suite:TLS-ECDHE-ECDSA-WITH-AES-256-GCM-SHA384]'
+		const result = parseDateTimeFromLogToTimestamp(logString)
+
+		assert.notEqual(result, null)
+		assert.equal(result, expected)
+	})
+
+	void it('should return null when an invalid log string is provided', () => {
+		const logString = 'Invalid log string'
+		const result = parseDateTimeFromLogToTimestamp(logString)
+
+		assert.equal(result, null)
+	})
+})

--- a/util/parseDateTimeFromLogToTimestamp.ts
+++ b/util/parseDateTimeFromLogToTimestamp.ts
@@ -1,0 +1,11 @@
+export const parseDateTimeFromLogToTimestamp = (
+	logString: string,
+): number | null => {
+	const matches = /^(?<date>[\d-]+\s[\d:,\\.]+)/.exec(logString)
+	if (matches === null) return null
+
+	const extractedDateTime = matches.groups?.date ?? ''
+	const ts = Date.parse(extractedDateTime.replace(/,/, '.'))
+
+	return isNaN(ts) ? null : ts
+}


### PR DESCRIPTION
## PR Type:
Bug fix

___
## PR Description:
This PR addresses the issue of inaccurate measurement of duration in the CoAP simulator due to the time taken to spawn the child process. The changes include:
- Using the timestamp from the CoAP simulator log instead of the message timestamp for more accurate duration calculation.
- Updating the AWS CDK monorepo to v2.108.0.
- Refactoring the code to improve readability and maintainability.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `cdk/resources/containers/coap/src/handler.ts`: Modified the 'run' function to filter out empty lines from the output. Added a new 'deviceDtlsSession' variable and included it in the arguments for the 'run' function. This is used to establish a session with the CoAP simulator.
- `lambda/healthCheckForCoAP.ts`: Modified the 'publishDeviceMessageOnCoAP' function to return the timestamp from the CoAP simulator log. Updated the 'h' function to store the CoAP timestamp and use it for duration calculation.
- `package-lock.json`: Updated the versions of 'aws-cdk', 'aws-cdk-lib', and 'cdk' to 2.108.0.
- `package.json`: Updated the versions of 'aws-cdk', 'aws-cdk-lib', and 'cdk' to 2.108.0.
</details>

___
## User Description:
We are using a message timestamp to calculate the duration which is not accurate in case of CoAP because of calling CoAP simulator via `child_process` will take times to spawn the child process which we need to take into the account when calculation. 

So, we will use a timestamp from CoAP simulator log instead. The timestamp we use is the first timestamp when CoAP simulator establishes the connection the same way as we do on MQTT measurement.
