### PR TITLE
feat(devices): only persist updated shadows

### DIFF
--- a/cdk/resources/DeviceShadow.ts
+++ b/cdk/resources/DeviceShadow.ts
@@ -109,7 +109,7 @@ export class DeviceShadow extends Construct {
 				layers,
 				initialPolicy: [
 					new IAM.PolicyStatement({
-						actions: ['iot:UpdateThingShadow'],
+						actions: ['iot:GetThingShadow', 'iot:UpdateThingShadow'],
 						resources: ['*'],
 					}),
 				],

--- a/historicalData/shadowDiff.spec.ts
+++ b/historicalData/shadowDiff.spec.ts
@@ -1,0 +1,72 @@
+import { describe, it } from 'node:test'
+import assert from 'node:assert/strict'
+import { shadowDiff } from './shadowDiff.js'
+
+void describe('shadowDiff()', () => {
+	void it('should not return an updated shadow, if it is already present in the shadow', () => {
+		const current = {
+			reported: {
+				'14205:1.0': {
+					'0': {
+						'0': 29.47,
+						'1': 24.19,
+						'2': 984.3000000000001,
+						'10': 26,
+						'99': 1718009832863,
+					},
+				},
+			},
+		}
+
+		const update = {
+			reported: {
+				'14205:1.0': {
+					'0': {
+						'2': 984.3000000000001,
+						'99': 1718009832863,
+					},
+				},
+			},
+		}
+
+		assert.deepEqual(shadowDiff(current, update), {})
+	})
+
+	void it('should return an updated shadow, if is not already present in the shadow', () => {
+		const current = {
+			reported: {
+				'14205:1.0': {
+					'0': {
+						'0': 29.47,
+						'1': 24.19,
+						'2': 984.3000000000001,
+						'10': 26,
+						'99': 1718009832863,
+					},
+				},
+			},
+		}
+
+		const update = {
+			reported: {
+				'14205:1.0': {
+					'0': {
+						'2': 985,
+						'99': 1718009832865,
+					},
+				},
+			},
+		}
+
+		assert.deepEqual(shadowDiff(current, update), {
+			reported: {
+				'14205:1.0': {
+					'0': {
+						'2': 985,
+						'99': 1718009832865,
+					},
+				},
+			},
+		})
+	})
+})

--- a/historicalData/shadowDiff.ts
+++ b/historicalData/shadowDiff.ts
@@ -1,0 +1,78 @@
+import type { LwM2MShadow } from '../lwm2m/objectsToShadow.js'
+
+const diffShadows = (
+	current: LwM2MShadow,
+	update: LwM2MShadow,
+): LwM2MShadow | undefined => {
+	const diff: LwM2MShadow = {}
+
+	for (const [ObjectIDAndVersion, Instances] of Object.entries(update)) {
+		if (current[ObjectIDAndVersion] === undefined) {
+			diff[ObjectIDAndVersion] = Instances
+			continue
+		}
+		for (const [InstanceId, Instance] of Object.entries(Instances)) {
+			const InstanceIdN = parseInt(InstanceId, 10)
+			if (current[ObjectIDAndVersion]![InstanceIdN] === undefined) {
+				if (diff[ObjectIDAndVersion] === undefined) {
+					diff[ObjectIDAndVersion] = {}
+				}
+				diff[ObjectIDAndVersion]![InstanceIdN] = Instance
+				continue
+			}
+			for (const [ResourceID, Value] of Object.entries(Instance)) {
+				const ResourceIDN = parseInt(ResourceID, 10)
+				if (current[ObjectIDAndVersion]![InstanceIdN]![ResourceIDN] !== Value) {
+					if (diff[ObjectIDAndVersion] === undefined) {
+						diff[ObjectIDAndVersion] = {}
+					}
+					if (diff[ObjectIDAndVersion]![InstanceIdN] === undefined) {
+						diff[ObjectIDAndVersion]![InstanceIdN] = {}
+					}
+					diff[ObjectIDAndVersion]![InstanceIdN]![ResourceIDN] = Value
+				}
+			}
+		}
+	}
+
+	if (Object.entries(diff).length === 0) return undefined
+
+	return diff
+}
+
+export const shadowDiff = (
+	current: {
+		reported?: LwM2MShadow
+		desired?: LwM2MShadow
+	},
+	update: {
+		reported?: LwM2MShadow
+		desired?: LwM2MShadow
+	},
+): {
+	reported?: LwM2MShadow
+	desired?: LwM2MShadow
+} => {
+	const diff: {
+		reported?: LwM2MShadow
+		desired?: LwM2MShadow
+	} = {}
+
+	const reportedDiff =
+		update.reported !== undefined && current.reported !== undefined
+			? diffShadows(current.reported, update.reported)
+			: undefined
+	if (reportedDiff !== undefined) {
+		diff.reported = reportedDiff
+	}
+
+	const desiredDiff =
+		update.desired !== undefined && current.desired !== undefined
+			? diffShadows(current.desired, update.desired)
+			: undefined
+	if (desiredDiff !== undefined) {
+		diff.desired = desiredDiff
+	}
+
+	return diff
+}


### PR DESCRIPTION
Otherwise the updates will be applied regardless,
and this will trigger a write to the history
database with the same value.
