### PR TITLE
fix: update to Node.js 22

### DIFF
--- a/cdk/BackendStack.ts
+++ b/cdk/BackendStack.ts
@@ -98,7 +98,7 @@ export class BackendStack extends Stack {
 				hash: baseLayer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const jwtLayerVersion = new Lambda.LayerVersion(this, 'jwtLayer', {
@@ -109,7 +109,7 @@ export class BackendStack extends Stack {
 				hash: jwtLayer.hash,
 			}).code,
 			compatibleArchitectures: [Lambda.Architecture.ARM_64],
-			compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+			compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 		})
 
 		const healthCheckLayerVersion = new Lambda.LayerVersion(
@@ -122,7 +122,7 @@ export class BackendStack extends Stack {
 					hash: healthCheckLayer.hash,
 				}).code,
 				compatibleArchitectures: [Lambda.Architecture.ARM_64],
-				compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+				compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 			},
 		)
 
@@ -179,7 +179,7 @@ export class BackendStack extends Stack {
 					hash: cdkLayer.hash,
 				}).code,
 				compatibleArchitectures: [Lambda.Architecture.ARM_64],
-				compatibleRuntimes: [Lambda.Runtime.NODEJS_20_X],
+				compatibleRuntimes: [Lambda.Runtime.NODEJS_22_X],
 			})
 			const domain = new APICustomDomain(this, {
 				api,


### PR DESCRIPTION
See https://aws.amazon.com/de/blogs/compute/node-js-22-runtime-now-available-in-aws-lambda/
