### PR TITLE
feat(hideDataBefore): delete the shadow

### DIFF
--- a/cdk/packBackendLambdas.ts
+++ b/cdk/packBackendLambdas.ts
@@ -39,6 +39,7 @@ export type BackendLambdas = {
 	fetchMemfaultReboots: PackedLambda
 	queryMemfaultReboots: PackedLambda
 	hideDataBefore: PackedLambda
+	onHideData: PackedLambda
 	createCNAMERecord: PackedLambda
 	multiBundleFOTAFlow: {
 		start: PackedLambda
@@ -121,6 +122,7 @@ export const packBackendLambdas = async (): Promise<BackendLambdas> => ({
 		'queryReboots',
 	),
 	hideDataBefore: await pack('hideDataBefore'),
+	onHideData: await pack('onHideData'),
 	createCNAMERecord: await packLambdaFromPath({
 		id: 'createCNAMERecord',
 		sourceFilePath: 'cdk/resources/api/createCNAMERecord.ts',

--- a/cdk/resources/DeviceStorage.ts
+++ b/cdk/resources/DeviceStorage.ts
@@ -18,6 +18,7 @@ export class DeviceStorage extends Construct {
 					? RemovalPolicy.DESTROY
 					: RemovalPolicy.RETAIN,
 			pointInTimeRecovery: true,
+			stream: DynamoDB.StreamViewType.NEW_IMAGE,
 		})
 		this.devicesTable.addGlobalSecondaryIndex({
 			indexName: this.devicesTableFingerprintIndexName,

--- a/cdk/resources/UpdateDevice.ts
+++ b/cdk/resources/UpdateDevice.ts
@@ -1,5 +1,9 @@
 import { PackedLambdaFn } from '@bifravst/aws-cdk-lambda-helpers/cdk'
-import type { aws_lambda as Lambda } from 'aws-cdk-lib'
+import {
+	aws_lambda_event_sources as EventSources,
+	aws_iam as IAM,
+	aws_lambda as Lambda,
+} from 'aws-cdk-lib'
 import { Construct } from 'constructs'
 import type { BackendLambdas } from '../packBackendLambdas.js'
 import type { DeviceStorage } from './DeviceStorage.js'
@@ -9,6 +13,7 @@ import type { DeviceStorage } from './DeviceStorage.js'
  */
 export class UpdateDevice extends Construct {
 	public readonly hideDataBeforeFn: PackedLambdaFn
+	public readonly onHideDataFn: PackedLambdaFn
 	public constructor(
 		parent: Construct,
 		{
@@ -16,7 +21,7 @@ export class UpdateDevice extends Construct {
 			layers,
 			deviceStorage,
 		}: {
-			lambdaSources: Pick<BackendLambdas, 'hideDataBefore'>
+			lambdaSources: Pick<BackendLambdas, 'hideDataBefore' | 'onHideData'>
 			layers: Lambda.ILayerVersion[]
 			deviceStorage: DeviceStorage
 		},
@@ -36,5 +41,41 @@ export class UpdateDevice extends Construct {
 			},
 		)
 		deviceStorage.devicesTable.grantReadWriteData(this.hideDataBeforeFn.fn)
+
+		this.onHideDataFn = new PackedLambdaFn(
+			this,
+			'onHideData',
+			lambdaSources.onHideData,
+			{
+				description: 'Processes the request to hide device data',
+				layers,
+				initialPolicy: [
+					new IAM.PolicyStatement({
+						actions: ['iot:DeleteThingShadow'],
+						resources: ['*'],
+					}),
+				],
+			},
+		)
+
+		this.onHideDataFn.fn.addEventSource(
+			new EventSources.DynamoEventSource(deviceStorage.devicesTable, {
+				startingPosition: Lambda.StartingPosition.LATEST,
+				filters: [
+					Lambda.FilterCriteria.filter({
+						dynamodb: {
+							NewImage: {
+								deviceId: {
+									S: [{ exists: true }],
+								},
+								hideDataBefore: {
+									S: [{ exists: true }],
+								},
+							},
+						},
+					}),
+				],
+			}),
+		)
 	}
 }

--- a/features/HideDataBefore.feature.md
+++ b/features/HideDataBefore.feature.md
@@ -96,3 +96,31 @@ And `{"len": $count(partialInstances)}` of the last response should match
 ```json
 { "len": 0 }
 ```
+
+## The shadow should have been deleted
+
+> The LwM2M shadow of the device should have been deleted.
+
+Given I reconnect to the websocket using fingerprint `${fingerprint}`
+
+Soon I should receive a message on the websocket that matches
+
+```json
+{
+  "@context": "https://github.com/hello-nrfcloud/proto/shadow",
+  "desired": [],
+  "reported": []
+}
+```
+
+And `{"len": $count(desired)}` of the last response should match
+
+```json
+{ "len": 0 }
+```
+
+And `{"len": $count(reported)}` of the last response should match
+
+```json
+{ "len": 0 }
+```

--- a/features/HideDataBefore.feature.md
+++ b/features/HideDataBefore.feature.md
@@ -113,13 +113,13 @@ Soon I should receive a message on the websocket that matches
 }
 ```
 
-And `$count(desired)"` of the last matched websocket message equals
+And `$count(desired)` of the last matched websocket message equals
 
 ```json
 0
 ```
 
-And `$count(reported)"` of the last matched websocket message equals
+And `$count(reported)` of the last matched websocket message equals
 
 ```json
 0

--- a/features/HideDataBefore.feature.md
+++ b/features/HideDataBefore.feature.md
@@ -113,14 +113,14 @@ Soon I should receive a message on the websocket that matches
 }
 ```
 
-And `{"len": $count(desired)}` of the last response should match
+And `$count(desired)"` of the last matched websocket message equals
 
 ```json
-{ "len": 0 }
+0
 ```
 
-And `{"len": $count(reported)}` of the last response should match
+And `$count(reported)"` of the last matched websocket message equals
 
 ```json
-{ "len": 0 }
+0
 ```

--- a/lambda/onConnect.ts
+++ b/lambda/onConnect.ts
@@ -105,6 +105,18 @@ const h = async (
 			deviceId,
 			error: maybeShadow.error.message,
 		})
+		// Send empty shadow in case it was hidden
+		if ('hideDataBefore' in context) {
+			await sendShadow({
+				deviceId,
+				model,
+				shadow: {
+					desired: [],
+					reported: [],
+				},
+				connectionId,
+			})
+		}
 	} else {
 		log.debug('sending shadow', {
 			deviceId,

--- a/lambda/onHideData.ts
+++ b/lambda/onHideData.ts
@@ -1,0 +1,38 @@
+import type { AttributeValue } from '@aws-sdk/client-dynamodb'
+import {
+	DeleteThingShadowCommand,
+	IoTDataPlaneClient,
+} from '@aws-sdk/client-iot-data-plane'
+import { unmarshall } from '@aws-sdk/util-dynamodb'
+import { requestLogger } from '@hello.nrfcloud.com/lambda-helpers/requestLogger'
+import middy from '@middy/core'
+import type { DynamoDBStreamEvent } from 'aws-lambda'
+
+const iotData = new IoTDataPlaneClient({})
+
+export const handler = middy()
+	.use(requestLogger())
+	.handler(async (event: DynamoDBStreamEvent): Promise<void> => {
+		for (const record of event.Records) {
+			const newImage = record.dynamodb?.NewImage
+			if (newImage === undefined) {
+				continue
+			}
+			const { deviceId, hideDataBefore } = unmarshall(
+				newImage as Record<string, AttributeValue>,
+			) as {
+				deviceId: string
+				hideDataBefore: string
+			}
+			console.log(
+				`Hiding data before ${hideDataBefore} for device ${deviceId}...`,
+			)
+			console.log('Deleting lwm2m shadow for device', deviceId)
+			await iotData.send(
+				new DeleteThingShadowCommand({
+					thingName: deviceId,
+					shadowName: 'lwm2m',
+				}),
+			)
+		}
+	})


### PR DESCRIPTION
This implements the deletion of the LwM2M shadow in
case the user requests the data to be hidden.

This then allows new "known" data to show up again.

Fixes hello-nrfcloud/web#927
