### PR TITLE
chore: upgrade to NPM v12

### DIFF
--- a/.github/actions/install-npm/action.yml
+++ b/.github/actions/install-npm/action.yml
@@ -1,0 +1,14 @@
+name: Install NPM
+description: >
+  Installs the NPM version required by the `engines.npm` directive in
+  package.json, which is required for the project to build correctly.
+
+runs:
+  using: composite
+  steps:
+    - name: Install NPM
+      shell: bash
+      run: |
+        npmVersion="$(node -p 'require(`${process.env.GITHUB_WORKSPACE}/package.json`).engines.npm')"
+        echo "Installing npm@${npmVersion}"
+        npm install -g "npm@${npmVersion}"

--- a/.github/workflows/cleanup.yaml
+++ b/.github/workflows/cleanup.yaml
@@ -33,8 +33,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -129,8 +129,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:

--- a/.github/workflows/test-and-release.yaml
+++ b/.github/workflows/test-and-release.yaml
@@ -31,8 +31,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit
@@ -67,8 +70,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit
@@ -129,8 +135,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit
@@ -189,8 +198,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6.5.0
         with:
@@ -296,8 +308,11 @@ jobs:
 
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.x"
+          node-version: ">=24.19.0 <25"
           cache: "npm"
+
+      - name: Install NPM version specified in package.json
+        uses: ./.github/actions/install-npm
 
       - name: Install dependencies
         run: npm ci --no-audit

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ developed using [AWS CDK](https://aws.amazon.com/cdk) in
 npm ci
 ```
 
+#### Node & NPM
+
+This project requires Node.js `>=24.19.0 <25` and npm `>=12.0.2 <13` (enforced
+via `check-node-version` on `npm install` and `npm ci`). The check is skipped
+during `npm publish` and `npm pack`, so it does not interfere with
+`semantic-release`, which runs its own dependency installation as part of the
+release process.
+
 The CoAP simulator is written in Golang, which needs to be
 [present on the local system](https://go.dev/dl/).
 

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "test": "node --experimental-transform-types --test --test-reporter spec \"!(dist|node_modules)/**/*.spec.ts\"",
     "test:e2e": "node --experimental-transform-types --no-warnings ./feature-runner/run-features.ts > e2e-test-result.json && cat e2e-test-result.json | node --experimental-transform-types --no-warnings ./feature-runner/console-reporter.ts --only-failed --with-timestamps",
-    "prepare": "husky && check-node-version --package"
+    "prepare": "husky && case \"$npm_command\" in install|ci) check-node-version --package ;; esac"
   },
   "repository": {
     "type": "git",
@@ -99,8 +99,8 @@
     ]
   },
   "engines": {
-    "node": ">=22.7.0",
-    "npm": ">=10"
+    "node": ">=24.19.0 <25",
+    "npm": ">=12.0.2 <13"
   },
   "release": {
     "branches": [


### PR DESCRIPTION
Require Node.js `>=24.19.0 <25` and npm `>=12.0.2 <13` (enforced via
`check-node-version` on `npm install` and `npm ci`).

The check is skipped during `npm publish` and `npm pack`, so it does not
interfere with `semantic-release`, which runs its own dependency installation
as part of the release process.

Note: `npm ci` currently fails on `saga` regardless of this change, due to a
pre-existing peer-dependency conflict (`@hello.nrfcloud.com/lambda-helpers@5.0.51`
requires `@aws-lambda-powertools/metrics@^2.33.1`, but the root pins `2.30.0`)
and a lockfile that is out of sync with `package.json` for the `@aws-sdk/*`
packages. Both predate this PR and are unrelated to the npm v12 upgrade.

🤖 Generated with [Claude Code](https://claude.com/claude-code)